### PR TITLE
Add GUI mp3 uploader script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Midi
+
+This repository contains a simple GUI tool to select and upload MP3 files.
+
+## Usage
+
+Run the script:
+
+```bash
+python gui_upload.py
+```

--- a/gui_upload.py
+++ b/gui_upload.py
@@ -1,0 +1,28 @@
+import tkinter as tk
+from tkinter import filedialog
+
+
+def select_file(label: tk.Label) -> None:
+    """Open a file dialog to select an MP3 file."""
+    filetypes = [("MP3 files", "*.mp3"), ("All files", "*.*")]
+    filename = filedialog.askopenfilename(title="Select an MP3 file", filetypes=filetypes)
+    if filename:
+        label.config(text=filename)
+
+
+def main() -> None:
+    root = tk.Tk()
+    root.title("MP3 Uploader")
+    root.geometry("400x150")
+
+    label = tk.Label(root, text="No file selected")
+    label.pack(pady=10)
+
+    button = tk.Button(root, text="Upload MP3", command=lambda: select_file(label))
+    button.pack(pady=20)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple Tkinter GUI to select MP3 files
- document script usage in README

## Testing
- `python gui_upload.py` *(fails: no GUI display in headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_684627d770c88326bce55e1af5b04b29