### PR TITLE
Add orchestral MIDI helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Simple utilities to convert between MIDI note numbers and note names.
 
 ## Coding
 
-The `midi` package provides two helper functions:
+The `midi` package provides a few helper functions:
 
-- `note_to_number(note)` converts a note name like 'C4' to a MIDI note number.
+- `note_to_number(note)` converts a note name like `C4` to a MIDI note number.
 - `number_to_note(number)` converts a MIDI note number back to a note name.
+- `create_orchestral_midi(layers)` builds a `mido.MidiFile` from multiple
+  instrument layers.
 
 A small command line interface is available via `python -m midi.cli`.
 
@@ -19,3 +21,17 @@ $ python -m midi.cli --note C4
 
 $ python -m midi.cli --number 60
 C4
+```
+
+#### Creating orchestral MIDI
+
+```python
+from midi import create_orchestral_midi
+
+layers = {
+    "piano": [(0.0, 60, 1.0, 64)],
+    "strings": [(0.5, 67, 1.5, 64)],
+}
+mid = create_orchestral_midi(layers)
+mid.save("score.mid")
+```

--- a/midi/__init__.py
+++ b/midi/__init__.py
@@ -1,3 +1,5 @@
+"""Minimal MIDI utilities."""
+
 NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
 
 
@@ -22,3 +24,14 @@ def number_to_note(number: int) -> str:
         raise ValueError("MIDI note number must be between 0 and 127")
     octave, index = divmod(number, 12)
     return f"{NOTE_NAMES[index]}{octave - 1}"
+
+
+from .orchestra import create_orchestral_midi, NoteEvent
+
+
+__all__ = [
+    "note_to_number",
+    "number_to_note",
+    "create_orchestral_midi",
+    "NoteEvent",
+]

--- a/midi/orchestra.py
+++ b/midi/orchestra.py
@@ -1,0 +1,63 @@
+"""Utilities for creating layered MIDI sequences."""
+
+from typing import Dict, Iterable, Tuple
+
+try:  # pragma: no cover - optional dependency
+    from mido import MidiFile, MidiTrack, Message, MetaMessage
+except Exception:  # pragma: no cover - mido missing
+    MidiFile = MidiTrack = Message = MetaMessage = None
+
+NoteEvent = Tuple[float, int, float, int]
+"""time (beats), note number, duration (beats), velocity"""
+
+
+def create_orchestral_midi(
+    layers: Dict[str, Iterable[NoteEvent]],
+    tempo: int = 500000,
+    ticks_per_beat: int = 480,
+) -> MidiFile:
+    """Return a ``MidiFile`` representing multiple instrument layers.
+
+    Parameters
+    ----------
+    layers:
+        Mapping of track names to iterables of ``NoteEvent`` tuples.
+    tempo:
+        Microseconds per beat (default 500000, i.e. 120 BPM).
+    ticks_per_beat:
+        Ticks per beat in the created ``MidiFile``.
+    """
+
+    if MidiFile is None:
+        raise ImportError("mido is required for create_orchestral_midi")
+
+    mid = MidiFile(ticks_per_beat=ticks_per_beat)
+
+    tempo_track = MidiTrack()
+    tempo_track.append(MetaMessage("set_tempo", tempo=tempo, time=0))
+    mid.tracks.append(tempo_track)
+
+    for name, events in layers.items():
+        track = MidiTrack()
+        track.name = name
+        mid.tracks.append(track)
+
+        current_tick = 0
+        for start, note, duration, velocity in sorted(events, key=lambda e: e[0]):
+            start_tick = int(start * ticks_per_beat)
+            delta = start_tick - current_tick
+            track.append(Message("note_on", note=note, velocity=velocity, time=delta))
+            track.append(
+                Message(
+                    "note_off",
+                    note=note,
+                    velocity=0,
+                    time=int(duration * ticks_per_beat),
+                )
+            )
+            current_tick = start_tick + int(duration * ticks_per_beat)
+
+    return mid
+
+
+__all__ = ["create_orchestral_midi", "NoteEvent"]

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -1,6 +1,10 @@
 import pytest
 
-from midi import note_to_number, number_to_note
+from midi import (
+    note_to_number,
+    number_to_note,
+    create_orchestral_midi,
+)
 
 
 def test_note_to_number():
@@ -11,6 +15,18 @@ def test_note_to_number():
 def test_number_to_note():
     assert number_to_note(60) == 'C4'
     assert number_to_note(69) == 'A4'
+
+
+def test_create_orchestral_midi():
+    mido = pytest.importorskip("mido")
+    layers = {
+        "piano": [(0.0, 60, 1.0, 64)],
+        "strings": [(0.5, 67, 1.5, 64)],
+    }
+    mid = create_orchestral_midi(layers)
+    assert isinstance(mid, mido.MidiFile)
+    # 1 tempo track + number of layers
+    assert len(mid.tracks) == 1 + len(layers)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- provide `create_orchestral_midi` for building multitrack MIDI files
- expose new helper through `midi` package
- expand README with orchestral example
- test new orchestral functionality

## Testing
- `PYTHONPATH=. pytest -q`
- `python -m midi.cli --note C4`

------
https://chatgpt.com/codex/tasks/task_e_68463104b8548326a02e2c0f588f1400