### PR TITLE
feat: add optional program per layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The `midi` package provides a few helper functions:
 - `note_to_number(note)` converts a note name like `C4` to a MIDI note number.
 - `number_to_note(number)` converts a MIDI note number back to a note name.
 - `create_orchestral_midi(layers)` builds a `mido.MidiFile` from multiple
-  instrument layers.
+  instrument layers. Each layer can optionally include a MIDI program number
+  to set the instrument for that track.
 
 A small command line interface is available via `python -m midi.cli`.
 
@@ -29,7 +30,7 @@ C4
 from midi import create_orchestral_midi
 
 layers = {
-    "piano": [(0.0, 60, 1.0, 64)],
+    "piano": ([(0.0, 60, 1.0, 64)], 0),  # program 0 (Acoustic Grand Piano)
     "strings": [(0.5, 67, 1.5, 64)],
 }
 mid = create_orchestral_midi(layers)

--- a/midi/orchestra.py
+++ b/midi/orchestra.py
@@ -1,6 +1,6 @@
 """Utilities for creating layered MIDI sequences."""
 
-from typing import Dict, Iterable, Tuple
+from typing import Dict, Iterable, Tuple, Optional, Union
 
 try:  # pragma: no cover - optional dependency
     from mido import MidiFile, MidiTrack, Message, MetaMessage
@@ -10,9 +10,13 @@ except Exception:  # pragma: no cover - mido missing
 NoteEvent = Tuple[float, int, float, int]
 """time (beats), note number, duration (beats), velocity"""
 
+# A layer can be provided either as an iterable of ``NoteEvent`` objects or as a
+# pair ``(events, program)`` where ``program`` is the MIDI program number.
+LayerSpec = Union[Iterable[NoteEvent], Tuple[Iterable[NoteEvent], int]]
+
 
 def create_orchestral_midi(
-    layers: Dict[str, Iterable[NoteEvent]],
+    layers: Dict[str, LayerSpec],
     tempo: int = 500000,
     ticks_per_beat: int = 480,
 ) -> MidiFile:
@@ -21,7 +25,9 @@ def create_orchestral_midi(
     Parameters
     ----------
     layers:
-        Mapping of track names to iterables of ``NoteEvent`` tuples.
+        Mapping of track names to either an iterable of ``NoteEvent`` tuples or
+        a pair ``(events, program)`` where ``program`` is the instrument number
+        to set via a ``program_change`` message at the start of the track.
     tempo:
         Microseconds per beat (default 500000, i.e. 120 BPM).
     ticks_per_beat:
@@ -37,9 +43,18 @@ def create_orchestral_midi(
     tempo_track.append(MetaMessage("set_tempo", tempo=tempo, time=0))
     mid.tracks.append(tempo_track)
 
-    for name, events in layers.items():
+    for name, spec in layers.items():
+        program: Optional[int] = None
+        events: Iterable[NoteEvent]
+        if isinstance(spec, tuple) and len(spec) == 2 and isinstance(spec[1], int):
+            events, program = spec
+        else:
+            events = spec
+
         track = MidiTrack()
         track.name = name
+        if program is not None:
+            track.append(Message("program_change", program=program, time=0))
         mid.tracks.append(track)
 
         current_tick = 0

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -29,5 +29,22 @@ def test_create_orchestral_midi():
     assert len(mid.tracks) == 1 + len(layers)
 
 
+def test_program_change():
+    mido = pytest.importorskip("mido")
+    layers = {
+        "piano": ([(0.0, 60, 1.0, 64)], 1),
+        "strings": [(0.5, 67, 1.5, 64)],
+    }
+    mid = create_orchestral_midi(layers)
+    piano_track = next(t for t in mid.tracks if getattr(t, "name", "") == "piano")
+    piano_program = next(msg for msg in piano_track if msg.type == "program_change")
+    assert piano_program.program == 1
+    assert piano_program.time == 0
+    strings_track = next(
+        t for t in mid.tracks if getattr(t, "name", "") == "strings"
+    )
+    assert all(msg.type != "program_change" for msg in strings_track)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
## Summary
- allow specifying an optional program number for each MIDI layer
- document program usage in README
- test program_change insertion per track

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c492381b70832684a387833da82913