### PR TITLE
Add pluggable audio separation backends

### DIFF
--- a/separation/__init__.py
+++ b/separation/__init__.py
@@ -1,0 +1,15 @@
+"""Source separation utilities."""
+
+from .base import BaseSeparator
+
+
+def get_separator(name: str) -> BaseSeparator:
+    """Return a separator instance for the given backend name."""
+    return BaseSeparator.create(name)
+
+
+# Import known backends so that they register with the factory.  Additional
+# backends can be added by simply importing them elsewhere in the project.
+from . import demucs_wrapper, spleeter_wrapper  # noqa: F401
+
+__all__ = ["BaseSeparator", "get_separator"]

--- a/separation/base.py
+++ b/separation/base.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Base classes and factory for source separation backends."""
+
+from abc import ABC, abstractmethod
+from typing import Dict, Type
+
+
+class BaseSeparator(ABC):
+    """Abstract base class for audio separation backends.
+
+    Subclasses register themselves by defining a unique ``name`` attribute.
+    ``BaseSeparator.create(name)`` can then be used to instantiate the
+    appropriate backend implementation.
+    """
+
+    #: registry of available separator implementations
+    registry: Dict[str, Type["BaseSeparator"]] = {}
+
+    #: unique name for the backend.  Subclasses must override.
+    name: str | None = None
+
+    def __init_subclass__(cls, **kwargs):  # type: ignore[override]
+        super().__init_subclass__(**kwargs)
+        # Register subclass if it defines a name
+        name = getattr(cls, "name", None)
+        if name:
+            BaseSeparator.registry[name] = cls
+
+    @classmethod
+    def create(cls, name: str) -> "BaseSeparator":
+        """Return a separator instance for the given backend name."""
+        try:
+            separator_cls = cls.registry[name]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Unknown separator backend: {name}") from exc
+        return separator_cls()
+
+    @abstractmethod
+    def separate(self, input_path: str, output_dir: str) -> None:
+        """Perform source separation on ``input_path``.
+
+        Implementations should write the separated stems to ``output_dir``.
+        """
+        raise NotImplementedError

--- a/separation/demucs_wrapper.py
+++ b/separation/demucs_wrapper.py
@@ -1,0 +1,25 @@
+"""Wrapper around the `demucs` command line tool."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from .base import BaseSeparator
+
+
+class DemucsSeparator(BaseSeparator):
+    """Audio separation using the `demucs` backend."""
+
+    name = "demucs"
+
+    def separate(self, input_path: str, output_dir: str) -> None:
+        input_path = str(Path(input_path))
+        output_dir = str(Path(output_dir))
+        cmd = ["demucs", "-o", output_dir, input_path]
+        subprocess.run(cmd, check=True)
+
+
+def separate(input_path: str, output_dir: str) -> None:
+    """Convenience function mirroring :meth:`BaseSeparator.separate`."""
+    DemucsSeparator().separate(input_path, output_dir)

--- a/separation/spleeter_wrapper.py
+++ b/separation/spleeter_wrapper.py
@@ -1,0 +1,25 @@
+"""Wrapper around the `spleeter` command line tool."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from .base import BaseSeparator
+
+
+class SpleeterSeparator(BaseSeparator):
+    """Audio separation using the `spleeter` backend."""
+
+    name = "spleeter"
+
+    def separate(self, input_path: str, output_dir: str) -> None:
+        input_path = str(Path(input_path))
+        output_dir = str(Path(output_dir))
+        cmd = ["spleeter", "separate", "-o", output_dir, input_path]
+        subprocess.run(cmd, check=True)
+
+
+def separate(input_path: str, output_dir: str) -> None:
+    """Convenience function mirroring :meth:`BaseSeparator.separate`."""
+    SpleeterSeparator().separate(input_path, output_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# Ensure project root is on sys.path when tests are executed via ``pytest``
+# as a console script (which does not automatically include the CWD).
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -1,0 +1,40 @@
+from unittest import mock
+
+from separation import get_separator
+from separation.demucs_wrapper import DemucsSeparator, separate as demucs_separate
+from separation.spleeter_wrapper import (
+    SpleeterSeparator,
+    separate as spleeter_separate,
+)
+
+
+def test_factory_returns_correct_class():
+    separator = get_separator("demucs")
+    assert isinstance(separator, DemucsSeparator)
+
+
+def test_demucs_wrapper_invokes_subprocess():
+    with mock.patch("subprocess.run") as run:
+        demucs_separate("input.wav", "out")
+        run.assert_called_once()
+        cmd = run.call_args[0][0]
+        assert cmd[0] == "demucs"
+        assert "-o" in cmd
+        assert cmd[-1] == "input.wav"
+
+
+def test_spleeter_wrapper_invokes_subprocess():
+    with mock.patch("subprocess.run") as run:
+        spleeter_separate("track.mp3", "out")
+        run.assert_called_once()
+        cmd = run.call_args[0][0]
+        assert cmd[0] == "spleeter" and cmd[1] == "separate"
+        assert "-o" in cmd
+        assert cmd[-1] == "track.mp3"
+
+
+def test_class_methods_call_subprocess():
+    sep = SpleeterSeparator()
+    with mock.patch("subprocess.run") as run:
+        sep.separate("song.wav", "out")
+        run.assert_called_once()


### PR DESCRIPTION
## Summary
- add a BaseSeparator registry and factory
- implement demucs and spleeter command wrappers with shared interface
- provide tests for separator factory and command invocation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4923131648326ac5a1a97b0559ee6