### PR TITLE
Add selectable separation backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ mid = create_orchestral_midi(layers)
 mid.save("score.mid")
 ```
 
+#### Selecting a separation backend
+
+```python
+from separation import get_separator
+
+separate = get_separator("spleeter")  # or "demucs"
+separate("track.wav", "stems/")
+```
+
 ## Project Structure
 
 Beyond the core `midi` utilities, the repository now includes placeholder packages for a complete audio production pipeline:
@@ -54,6 +63,8 @@ Beyond the core `midi` utilities, the repository now includes placeholder packag
   - `suno_wrapper.py` – stub for integrating with the Suno API.
 - `separation/` – tools for stem separation.
   - `demucs_wrapper.py` – stub for Demucs-based separation.
+  - `spleeter_wrapper.py` – stub for Spleeter-based separation.
+  - `__init__.py` – factory exposing `get_separator` to pick a backend.
 - `upscaling/` – audio enhancement and upscaling helpers.
   - `upscaler_wrapper.py` – stub for future upscaling models.
 - `mix_prep/` – preparation steps prior to mixing.

--- a/separation/__init__.py
+++ b/separation/__init__.py
@@ -1,1 +1,19 @@
 """Audio source separation utilities."""
+
+from . import demucs_wrapper, spleeter_wrapper
+
+
+def get_separator(backend: str = "demucs"):
+    """Return a separation function for the requested backend.
+
+    Parameters
+    ----------
+    backend: str
+        Name of the backend to use ("demucs" or "spleeter").
+    """
+    backend = backend.lower()
+    if backend == "demucs":
+        return demucs_wrapper.separate
+    if backend == "spleeter":
+        return spleeter_wrapper.separate
+    raise ValueError(f"Unknown separation backend: {backend}")

--- a/separation/demucs_wrapper.py
+++ b/separation/demucs_wrapper.py
@@ -1,3 +1,6 @@
 """Placeholder for Demucs source separation wrapper."""
 
-pass
+
+def separate(input_path, output_dir):
+    """Separate audio into stems using Demucs (stub)."""
+    raise NotImplementedError("Demucs separation not implemented.")

--- a/separation/spleeter_wrapper.py
+++ b/separation/spleeter_wrapper.py
@@ -1,0 +1,6 @@
+"""Placeholder for Spleeter source separation wrapper."""
+
+
+def separate(input_path, output_dir):
+    """Separate audio into stems using Spleeter (stub)."""
+    raise NotImplementedError("Spleeter separation not implemented.")


### PR DESCRIPTION
## Summary
- add Spleeter separation wrapper
- provide `get_separator` factory for Demucs or Spleeter
- document backend selection in README

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4c9a7598c832693bac96bab86c16b