### PR TITLE
Add vocal and guitar upscalers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Beyond the core `midi` utilities, the repository now includes placeholder packag
 - `separation/` – tools for stem separation.
   - `demucs_wrapper.py` – stub for Demucs-based separation.
 - `upscaling/` – audio enhancement and upscaling helpers.
-  - `upscaler_wrapper.py` – stub for future upscaling models.
+  - `voc_upscaler.py` – placeholder vocal enhancer.
+  - `guitar_upscaler.py` – placeholder guitar track enhancer.
+  - `utils.py` – shared utilities for loading models.
 - `mix_prep/` – preparation steps prior to mixing.
   - `mix_prep_wrapper.py` – stub for organizing and cleaning stems.
 - `human_mix/` – modules supporting human-in-the-loop mixing.

--- a/upscaling/__init__.py
+++ b/upscaling/__init__.py
@@ -1,1 +1,11 @@
-"""Audio upscaling and enhancement utilities."""
+"""Audio upscaling and enhancement utilities.
+
+Modules
+-------
+``voc_upscaler``
+    Placeholder vocal enhancement functions.
+``guitar_upscaler``
+    Placeholder guitar track enhancer.
+``utils``
+    Shared helpers for loading model objects.
+"""

--- a/upscaling/guitar_upscaler.py
+++ b/upscaling/guitar_upscaler.py
@@ -1,0 +1,40 @@
+"""Guitar track upscaling utilities.
+
+Model source: `StrumLift` – an imaginary model trained on studio guitar
+recordings hosted at https://example.com/models/strumlift.  The model expects
+stereo 48 kHz WAV files as input and produces an enhanced track at the same
+sample rate.
+
+The module exposes a single :func:`enhance` function.  The current
+implementation loads the model and simply copies the input to the output path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+from .utils import load_model
+
+_MODEL_NAME = "strumlift_v1"
+
+
+def enhance(input_path: str | Path, output_path: str | Path) -> str:
+    """Enhance a guitar recording.
+
+    Parameters
+    ----------
+    input_path:
+        Path to a stereo 48 kHz WAV file containing the guitar track.
+    output_path:
+        Destination path for the enhanced audio.
+
+    Returns
+    -------
+    str
+        The ``output_path`` where the enhanced audio was saved.
+    """
+
+    load_model(_MODEL_NAME)
+    shutil.copyfile(input_path, output_path)
+    return str(output_path)

--- a/upscaling/upscaler_wrapper.py
+++ b/upscaling/upscaler_wrapper.py
@@ -1,3 +1,0 @@
-"""Placeholder for audio upscaling wrapper."""
-
-pass

--- a/upscaling/utils.py
+++ b/upscaling/utils.py
@@ -1,0 +1,31 @@
+"""Shared helpers for audio upscaling models.
+
+This module centralizes common functionality such as model loading.  The
+actual models are placeholders; in a real project these functions would load
+pre-trained neural networks from disk or download them on demand.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+
+@lru_cache()
+def load_model(name: str) -> dict[str, Any]:
+    """Load and cache an upscaling model by name.
+
+    Parameters
+    ----------
+    name:
+        Identifier of the model to load.
+
+    Returns
+    -------
+    dict[str, Any]
+        Placeholder object representing the loaded model.
+    """
+
+    # In this stub implementation we simply return a dictionary describing the
+    # model.  Real implementations would perform I/O here.
+    return {"model": name}

--- a/upscaling/voc_upscaler.py
+++ b/upscaling/voc_upscaler.py
@@ -1,0 +1,41 @@
+"""Vocal upscaling utilities.
+
+Model source: `UltraVox` – a fictional neural network for vocal enhancement
+available from https://example.com/models/ultravox.  The model expects mono
+44.1 kHz WAV files as input and outputs an enhanced version at the same sample
+rate.
+
+The main entry point is :func:`enhance`, which loads the model and writes the
+processed audio to disk.  In this placeholder implementation the input file is
+simply copied to the destination.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+from .utils import load_model
+
+_MODEL_NAME = "ultravox_v1"
+
+
+def enhance(input_path: str | Path, output_path: str | Path) -> str:
+    """Enhance a vocal recording.
+
+    Parameters
+    ----------
+    input_path:
+        Path to a mono 44.1 kHz WAV file containing the vocals.
+    output_path:
+        Destination path where the enhanced audio will be written.
+
+    Returns
+    -------
+    str
+        The ``output_path`` where the enhanced audio was saved.
+    """
+
+    load_model(_MODEL_NAME)
+    shutil.copyfile(input_path, output_path)
+    return str(output_path)


### PR DESCRIPTION
## Summary
- split generic upscaler stub into dedicated vocal and guitar modules
- add shared model loading utilities
- update package docs to reference new upscalers

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4c9b1c1d883269e4758c2f4e61a09