### PR TITLE
Add basic AI mastering utilities and CLI

### DIFF
--- a/mastering/__init__.py
+++ b/mastering/__init__.py
@@ -1,1 +1,5 @@
 """Automated mastering utilities."""
+
+from .ai_master import master_track
+
+__all__ = ["master_track"]

--- a/mastering/ai_master.py
+++ b/mastering/ai_master.py
@@ -1,0 +1,88 @@
+"""Basic loudness normalization and limiting for audio tracks."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import soundfile as sf
+
+try:  # pragma: no cover - optional dependency
+    import pyloudnorm as pyln
+except Exception:  # pragma: no cover
+    pyln = None
+
+
+def _integrated_loudness(audio: np.ndarray, rate: int) -> float:
+    """Return integrated loudness of ``audio`` in LUFS.
+
+    Parameters
+    ----------
+    audio:
+        Audio samples with shape ``(n_samples, n_channels)`` or ``(n_samples,)``.
+    rate:
+        Sampling rate in Hz.
+    """
+    if pyln is None:
+        # Fallback: use simple RMS-based approximation
+        rms = np.sqrt(np.mean(np.square(audio)))
+        return 20 * np.log10(rms + 1e-12)
+    meter = pyln.Meter(rate)
+    return meter.integrated_loudness(audio)
+
+
+def master_track(
+    input_path: Union[str, Path],
+    output_path: Union[str, Path],
+    target_lufs: float = -14.0,
+) -> None:
+    """Normalize ``input_path`` to ``target_lufs`` and apply peak limiting.
+
+    Parameters
+    ----------
+    input_path:
+        Path to the input audio file.
+    output_path:
+        Where the mastered audio will be written.
+    target_lufs:
+        Desired loudness level in LUFS. Defaults to -14, a common streaming target.
+    """
+    data, rate = sf.read(str(input_path))
+    multi_channel = data.ndim > 1
+    if multi_channel and pyln is not None:
+        # pyloudnorm expects channels first
+        audio = data.T
+    else:
+        audio = data
+    loudness = _integrated_loudness(audio, rate)
+    gain_db = target_lufs - loudness
+    gain = 10 ** (gain_db / 20)
+    normalized = audio * gain
+    limited = np.clip(normalized, -1.0, 1.0)
+    if multi_channel and pyln is not None:
+        limited = limited.T
+    sf.write(str(output_path), limited, rate)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for command line execution."""
+    parser = argparse.ArgumentParser(description="Simple AI mastering")
+    parser.add_argument("input", help="Path to input audio file")
+    parser.add_argument("output", help="Path for mastered output")
+    parser.add_argument(
+        "--target-lufs",
+        type=float,
+        default=-14.0,
+        help="Target loudness in LUFS (default: -14)",
+    )
+    args = parser.parse_args(argv)
+    master_track(args.input, args.output, args.target_lufs)
+    print(f"Mastered file written to {args.output}")
+
+
+__all__ = ["master_track", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/mastering/human_master_guides.md
+++ b/mastering/human_master_guides.md
@@ -1,0 +1,19 @@
+# Human Mastering Tips
+
+While automated tools provide a fast starting point, professional mastering often requires
+human judgment. Consider the following tips when refining a mix manually or using
+proprietary mastering suites:
+
+- **Reference tracks**: Compare your mix against commercially released songs in the same
+genre to judge tonal balance and loudness.
+- **Broadband EQ**: Small, wide adjustments can correct overall spectral imbalances.
+- **Stereo imaging**: Moderate widening can enhance space, but avoid phase issues by
+checking the mix in mono.
+- **Dynamics**: Gentle multiband compression can control problematic frequency ranges
+without squashing the entire mix.
+- **Limiter selection**: Different limiters impart distinct characters. Test a few
+algorithms to find the one that preserves transients best.
+- **Fresh ears**: Take breaks and evaluate the track on multiple playback systems before
+signing off on the master.
+
+These practices complement automated mastering and can yield more polished results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ dependencies = [
     "mido",
     "requests",
 ]
+
+[project.scripts]
+ai-master = "mastering.ai_master:main"


### PR DESCRIPTION
## Summary
- implement loudness normalization and limiting in `master_track`
- document manual mastering tips
- add `ai-master` CLI entry for running mastering from command line

## Testing
- `python -m pytest tests/test_midi.py -vv`
- `python -m mastering.ai_master --help`


------
https://chatgpt.com/codex/tasks/task_e_68c4c9b41afc8326b654d92e3ea02ef3