### PR TITLE
Add demo pipeline notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ $ python -m midi.cli --number 60
 C4
 ```
 
+### Demo Pipeline Notebook
+
+For an end-to-end walk-through of the broader audio workflow, open
+[`examples/demo_pipeline.ipynb`](examples/demo_pipeline.ipynb). It steps
+through generation → separation → mix prep → mastering.
+
+If you need a small test file, download an open sample clip:
+
+```bash
+curl -L -o examples/sample_clip.wav https://www2.cs.uic.edu/~i101/SoundFiles/StarWars60.wav
+```
+
+Then launch the notebook and follow the instructions.
+
 #### Creating orchestral MIDI
 
 ```python
@@ -63,6 +77,6 @@ Beyond the core `midi` utilities, the repository now includes placeholder packag
 - `mastering/` – final mastering stages.
   - `mastering_wrapper.py` – stub for automated mastering.
 - `examples/` – demonstration scripts showing how modules fit together.
-  - `example_workflow.py` – minimal example pipeline.
+  - `demo_pipeline.ipynb` – interactive notebook walking through generation → separation → mix prep → mastering.
 
 These modules are placeholders and will be fleshed out as the project evolves.

--- a/examples/demo_pipeline.ipynb
+++ b/examples/demo_pipeline.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo Pipeline\n",
+    "\n",
+    "This notebook demonstrates a simple end-to-end audio workflow:\n",
+    "1. **Generation** – create a starting track with `generation.suno_wrapper`.\n",
+    "2. **Separation** – split the track into stems using `separation.demucs_wrapper`.\n",
+    "3. **Mix Prep** – organize stems for mixing with `mix_prep.mix_prep_wrapper`.\n",
+    "4. **Mastering** – finalize the mix with `mastering.mastering_wrapper`.\n",
+    "\n",
+    "The included code cells are placeholders; replace them with real implementations as the project evolves."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sample Audio\n",
+    "\n",
+    "If you don't have an audio file handy, download a small open clip:\n",
+    "```bash\n",
+    "curl -L -o sample_clip.wav https://www2.cs.uic.edu/~i101/SoundFiles/StarWars60.wav\n",
+    "```\n",
+    "The rest of the notebook assumes `sample_clip.wav` exists in the current working directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from generation import suno_wrapper\n",
+    "from separation import demucs_wrapper\n",
+    "from mix_prep import mix_prep_wrapper\n",
+    "from mastering import mastering_wrapper\n",
+    "\n",
+    "# Step 1: Generation\n",
+    "generated = \"generated.wav\"\n",
+    "# suno_wrapper.generate_track(generated, prompt=\"lofi hiphop beat\")\n",
+    "\n",
+    "# Step 2: Separation\n",
+    "# stems_dir = demucs_wrapper.separate_stems(generated)\n",
+    "\n",
+    "# For demonstration we'll reuse the sample file\n",
+    "stems_dir = \"stems/\"\n",
+    "\n",
+    "# Step 3: Mix Preparation\n",
+    "# mix_ready = mix_prep_wrapper.prepare_mix(stems_dir)\n",
+    "mix_ready = stems_dir\n",
+    "\n",
+    "# Step 4: Mastering\n",
+    "# master = mastering_wrapper.master_track(mix_ready)\n",
+    "master = mix_ready\n",
+    "\n",
+    "print(\"Generated:\", generated)\n",
+    "print(\"Stems in:\", stems_dir)\n",
+    "print(\"Final master:\", master)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/example_workflow.py
+++ b/examples/example_workflow.py
@@ -1,3 +1,0 @@
-"""Placeholder for an end-to-end audio pipeline example."""
-
-pass


### PR DESCRIPTION
## Summary
- replace placeholder `example_workflow.py` with `examples/demo_pipeline.ipynb` showing generation → separation → mix prep → mastering
- document sample audio download and notebook onboarding in README

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4c9b6764883268e7afe4d444b53e7