### PR TITLE
Support flats and case-insensitive note names

### DIFF
--- a/midi/__init__.py
+++ b/midi/__init__.py
@@ -1,11 +1,65 @@
 """Minimal MIDI utilities."""
 
-NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+# Mapping from note names to their semitone index within an octave.  Both
+# sharps and flats are supported and note names are normalized to uppercase
+# by :func:`note_to_number`.
+NOTE_NAMES = {
+    "C": 0,
+    "C#": 1,
+    "DB": 1,
+    "D": 2,
+    "D#": 3,
+    "EB": 3,
+    "E": 4,
+    "F": 5,
+    "F#": 6,
+    "GB": 6,
+    "G": 7,
+    "G#": 8,
+    "AB": 8,
+    "A": 9,
+    "A#": 10,
+    "BB": 10,
+    "B": 11,
+}
+
+# Canonical sharp and flat representations for mapping a semitone index back to
+# a note name.  :func:`number_to_note` defaults to the sharp names but can
+# optionally return the flat equivalents.
+NOTE_NAMES_SHARP = [
+    "C",
+    "C#",
+    "D",
+    "D#",
+    "E",
+    "F",
+    "F#",
+    "G",
+    "G#",
+    "A",
+    "A#",
+    "B",
+]
+
+NOTE_NAMES_FLAT = [
+    "C",
+    "Db",
+    "D",
+    "Eb",
+    "E",
+    "F",
+    "Gb",
+    "G",
+    "Ab",
+    "A",
+    "Bb",
+    "B",
+]
 
 
 def note_to_number(note: str) -> int:
-    """Convert a note name like 'C4' to a MIDI note number."""
-    note = note.strip()
+    """Convert a note name like 'C4' or 'Db4' to a MIDI note number."""
+    note = note.strip().upper()
     if len(note) < 2:
         raise ValueError("Invalid note format")
     if note[-1].isdigit():
@@ -15,15 +69,24 @@ def note_to_number(note: str) -> int:
         raise ValueError("Note must end with octave number")
     if name not in NOTE_NAMES:
         raise ValueError(f"Invalid note name: {name}")
-    return NOTE_NAMES.index(name) + (octave + 1) * 12
+    return NOTE_NAMES[name] + (octave + 1) * 12
 
 
-def number_to_note(number: int) -> str:
-    """Convert a MIDI note number to its note name."""
+def number_to_note(number: int, prefer_sharps: bool = True) -> str:
+    """Convert a MIDI note number to its note name.
+
+    Parameters
+    ----------
+    number:
+        MIDI note number (0-127).
+    prefer_sharps:
+        If ``True`` (default) use sharp notation, otherwise use flats.
+    """
     if not (0 <= number <= 127):
         raise ValueError("MIDI note number must be between 0 and 127")
     octave, index = divmod(number, 12)
-    return f"{NOTE_NAMES[index]}{octave - 1}"
+    names = NOTE_NAMES_SHARP if prefer_sharps else NOTE_NAMES_FLAT
+    return f"{names[index]}{octave - 1}"
 
 
 from .orchestra import create_orchestral_midi, NoteEvent

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -10,11 +10,18 @@ from midi import (
 def test_note_to_number():
     assert note_to_number('C4') == 60
     assert note_to_number('A4') == 69
+    # Flats map to their sharp equivalents and input is case-insensitive
+    assert note_to_number('Db4') == note_to_number('C#4')
+    assert note_to_number('c4') == 60
 
 
 def test_number_to_note():
     assert number_to_note(60) == 'C4'
     assert number_to_note(69) == 'A4'
+    # Conversions handle sharps and flats
+    assert number_to_note(note_to_number('Db4')) == 'C#4'
+    assert number_to_note(note_to_number('C#4'), prefer_sharps=False) == 'Db4'
+    assert number_to_note(note_to_number('db4')) == 'C#4'
 
 
 def test_create_orchestral_midi():


### PR DESCRIPTION
## Summary
- Allow both sharp and flat note names with unified mapping
- Normalize input note strings to uppercase and add optional flat output
- Test flat↔sharp conversions and lowercase note handling

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4c9b80e308326be8fe46172c6155d