### PR TITLE
Handle flat notes and case-insensitive note names

### DIFF
--- a/midi/__init__.py
+++ b/midi/__init__.py
@@ -1,6 +1,43 @@
 """Minimal MIDI utilities."""
 
-NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+# Standard note names using sharps for indexing
+NOTE_NAMES = [
+    "C",
+    "C#",
+    "D",
+    "D#",
+    "E",
+    "F",
+    "F#",
+    "G",
+    "G#",
+    "A",
+    "A#",
+    "B",
+]
+
+# Equivalent note names expressed with flats. These are used for output so
+# that either form can round-trip through the conversion functions.
+NOTE_NAMES_FLAT = [
+    "C",
+    "Db",
+    "D",
+    "Eb",
+    "E",
+    "F",
+    "Gb",
+    "G",
+    "Ab",
+    "A",
+    "Bb",
+    "B",
+]
+
+# Mapping from any accepted note name (sharp or flat) to its index within an
+# octave. The keys are normalised to have a capital letter followed by any
+# accidental.
+NOTE_NAME_TO_INDEX = {name: i for i, name in enumerate(NOTE_NAMES)}
+NOTE_NAME_TO_INDEX.update({name: i for i, name in enumerate(NOTE_NAMES_FLAT)})
 
 
 def note_to_number(note: str) -> int:
@@ -13,9 +50,10 @@ def note_to_number(note: str) -> int:
         name = note[:-1]
     else:
         raise ValueError("Note must end with octave number")
-    if name not in NOTE_NAMES:
+    name = name[0].upper() + name[1:].lower()
+    if name not in NOTE_NAME_TO_INDEX:
         raise ValueError(f"Invalid note name: {name}")
-    return NOTE_NAMES.index(name) + (octave + 1) * 12
+    return NOTE_NAME_TO_INDEX[name] + (octave + 1) * 12
 
 
 def number_to_note(number: int) -> str:
@@ -23,7 +61,7 @@ def number_to_note(number: int) -> str:
     if not (0 <= number <= 127):
         raise ValueError("MIDI note number must be between 0 and 127")
     octave, index = divmod(number, 12)
-    return f"{NOTE_NAMES[index]}{octave - 1}"
+    return f"{NOTE_NAMES_FLAT[index]}{octave - 1}"
 
 
 from .orchestra import create_orchestral_midi, NoteEvent

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -10,11 +10,15 @@ from midi import (
 def test_note_to_number():
     assert note_to_number('C4') == 60
     assert note_to_number('A4') == 69
+    assert note_to_number('Db4') == 61
+    assert note_to_number('db4') == 61
 
 
 def test_number_to_note():
     assert number_to_note(60) == 'C4'
     assert number_to_note(69) == 'A4'
+    assert number_to_note(61) == 'Db4'
+    assert number_to_note(61).lower() == 'db4'
 
 
 def test_create_orchestral_midi():


### PR DESCRIPTION
## Summary
- Support flat note names and case-insensitive input in note conversion helpers
- Extend MIDI tests to validate flat/sharp mapping and lowercase inputs

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4c9b9240883268a7edca2bf6e34f2