### PR TITLE
Add mix preparation and mastering utilities

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on the module search path for tests
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/human_mix/human_mix_wrapper.py
+++ b/human_mix/human_mix_wrapper.py
@@ -1,3 +1,114 @@
-"""Placeholder for human-guided mixing workflows."""
+from __future__ import annotations
 
-pass
+"""Helpers for human-guided mixing workflows.
+
+This module connects the reference mix analysis utilities with reusable
+effect-chain templates.  It intentionally implements only lightweight
+processing suitable for examples and tests.
+"""
+
+from typing import Dict, List
+
+import numpy as np
+
+from .reference_mixer import compare_to_reference
+from .effect_chain_templates import Effect, EffectChain, get_template
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def analyze(reference_path: str, stems: Dict[str, str]) -> Dict[str, List[str]]:
+    """Return mix suggestions by comparing stems to a reference track."""
+
+    return compare_to_reference(reference_path, stems)
+
+
+def available_templates() -> List[str]:
+    """List the names of built-in effect chain templates."""
+
+    from .effect_chain_templates import TEMPLATES
+
+    return sorted(TEMPLATES.keys())
+
+
+def apply_template(audio: np.ndarray, sr: int, template: str) -> np.ndarray:
+    """Apply a named effect-chain template to ``audio``."""
+
+    chain = get_template(template)
+    return apply_chain(audio, sr, chain)
+
+
+def apply_chain(audio: np.ndarray, sr: int, chain: EffectChain) -> np.ndarray:
+    """Apply a sequence of :class:`~Effect` instances to ``audio``."""
+
+    processed = audio.copy()
+    for effect in chain:
+        processed = _apply_effect(processed, sr, effect)
+    return processed
+
+
+# ---------------------------------------------------------------------------
+# Effect implementations (very naive)
+# ---------------------------------------------------------------------------
+
+def _apply_effect(audio: np.ndarray, sr: int, effect: Effect) -> np.ndarray:
+    name = effect.name.lower()
+    params = effect.params
+    if name == "highpass":
+        return _highpass(audio, sr, params.get("freq", 100))
+    if name == "compressor":
+        return _compressor(audio, params.get("ratio", 2.0))
+    if name == "de-esser":
+        return _de_esser(audio, sr, params.get("freq", 6000))
+    if name == "eq":
+        return _eq(audio, sr, params.get("freq", 1000), params.get("gain", 0.0))
+    if name == "reverb":
+        return _reverb(audio, sr, params.get("room_size", 0.3), params.get("wet", 0.3))
+    return audio
+
+
+def _highpass(audio: np.ndarray, sr: int, freq: float) -> np.ndarray:
+    spec = np.fft.rfft(audio)
+    freqs = np.fft.rfftfreq(audio.size, 1.0 / sr)
+    spec[freqs < freq] = 0
+    return np.fft.irfft(spec, n=audio.size).astype(audio.dtype)
+
+
+def _compressor(audio: np.ndarray, ratio: float) -> np.ndarray:
+    thr = np.sqrt(np.mean(np.square(audio))) + 1e-9
+    out = audio.copy()
+    above = np.abs(audio) > thr
+    out[above] = np.sign(audio[above]) * (thr + (np.abs(audio[above]) - thr) / ratio)
+    return out.astype(audio.dtype)
+
+
+def _de_esser(audio: np.ndarray, sr: int, freq: float) -> np.ndarray:
+    spec = np.fft.rfft(audio)
+    freqs = np.fft.rfftfreq(audio.size, 1.0 / sr)
+    spec[freqs > freq] *= 0.5
+    return np.fft.irfft(spec, n=audio.size).astype(audio.dtype)
+
+
+def _eq(audio: np.ndarray, sr: int, freq: float, gain: float) -> np.ndarray:
+    spec = np.fft.rfft(audio)
+    freqs = np.fft.rfftfreq(audio.size, 1.0 / sr)
+    bandwidth = max(freq * 0.1, 1.0)
+    band = (freqs >= freq - bandwidth) & (freqs <= freq + bandwidth)
+    spec[band] *= 10 ** (gain / 20)
+    return np.fft.irfft(spec, n=audio.size).astype(audio.dtype)
+
+
+def _reverb(audio: np.ndarray, sr: int, room_size: float, wet: float) -> np.ndarray:
+    delay = max(int(sr * room_size * 0.03), 1)
+    wet_sig = np.zeros(audio.size + delay)
+    wet_sig[delay:] = audio * wet
+    dry_sig = np.zeros_like(wet_sig)
+    dry_sig[: audio.size] = audio * (1 - wet)
+    out = dry_sig
+    out[: wet_sig.size] += wet_sig[: out.size]
+    return out[: audio.size].astype(audio.dtype)
+
+
+__all__ = ["analyze", "available_templates", "apply_template", "apply_chain"]

--- a/mastering/mastering_wrapper.py
+++ b/mastering/mastering_wrapper.py
@@ -1,3 +1,30 @@
-"""Placeholder for mastering stage wrapper."""
+from __future__ import annotations
 
-pass
+"""Entry point wrapper around :func:`ai_master.master_track`."""
+
+import argparse
+
+from .ai_master import master_track
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point for simple mastering."""
+
+    parser = argparse.ArgumentParser(description="Simple mastering wrapper")
+    parser.add_argument("input", help="Path to input audio file")
+    parser.add_argument("output", help="Path for mastered output")
+    parser.add_argument(
+        "--target-lufs",
+        type=float,
+        default=-14.0,
+        help="Target loudness in LUFS (default: -14)",
+    )
+    args = parser.parse_args(argv)
+    master_track(args.input, args.output, args.target_lufs)
+
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/mix_prep/__init__.py
+++ b/mix_prep/__init__.py
@@ -1,1 +1,15 @@
 """Utilities for preparing tracks before mixing."""
+
+from .auto_eq import auto_eq, match_spectrum
+from .multiband_compression import multiband_compress
+from .noise_reduction import spectral_gate
+from .stereo_imaging import stereo_widen, to_stereo
+
+__all__ = [
+    "auto_eq",
+    "match_spectrum",
+    "multiband_compress",
+    "spectral_gate",
+    "stereo_widen",
+    "to_stereo",
+]

--- a/mix_prep/auto_eq.py
+++ b/mix_prep/auto_eq.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Simple automatic equalization utilities."""
+
+import numpy as np
+
+
+def auto_eq(audio: np.ndarray, sr: int) -> np.ndarray:
+    """Perform a crude inverse-EQ to flatten the spectrum of ``audio``.
+
+    Parameters
+    ----------
+    audio:
+        Mono audio signal as a 1-D numpy array.
+    sr:
+        Sampling rate in Hz.
+
+    Returns
+    -------
+    numpy.ndarray
+        Equalized audio of the same shape as ``audio``.
+    """
+
+    spectrum = np.fft.rfft(audio)
+    magnitude = np.abs(spectrum)
+    # Smooth the spectrum to obtain a basic target curve
+    smooth = np.convolve(magnitude, np.ones(5) / 5, mode="same")
+    target = np.mean(smooth)
+    correction = target / (smooth + 1e-9)
+    corrected = spectrum * correction
+    return np.fft.irfft(corrected, n=audio.size).astype(audio.dtype)
+
+
+def match_spectrum(source: np.ndarray, reference: np.ndarray, sr: int) -> np.ndarray:
+    """Match the spectral envelope of ``source`` to ``reference``.
+
+    This uses a simplistic FFT magnitude transfer and should be considered a
+    placeholder for more advanced matching EQ algorithms.
+    """
+
+    spec_src = np.fft.rfft(source)
+    spec_ref = np.fft.rfft(reference, n=source.size)
+    gain = (np.abs(spec_ref) + 1e-9) / (np.abs(spec_src) + 1e-9)
+    matched = spec_src * gain
+    return np.fft.irfft(matched, n=source.size).astype(source.dtype)
+
+
+__all__ = ["auto_eq", "match_spectrum"]

--- a/mix_prep/mix_prep_wrapper.py
+++ b/mix_prep/mix_prep_wrapper.py
@@ -1,3 +1,0 @@
-"""Placeholder for mix preparation routines."""
-
-pass

--- a/mix_prep/multiband_compression.py
+++ b/mix_prep/multiband_compression.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Very lightweight multi-band compressor."""
+
+import numpy as np
+
+BANDS = [(20, 250), (250, 4000), (4000, None)]
+
+
+def _bandpass(audio: np.ndarray, sr: int, low: float, high: float | None) -> np.ndarray:
+    spec = np.fft.rfft(audio)
+    freqs = np.fft.rfftfreq(audio.size, 1.0 / sr)
+    mask = freqs >= low
+    if high is not None:
+        mask &= freqs < high
+    filtered = np.zeros_like(spec)
+    filtered[mask] = spec[mask]
+    return np.fft.irfft(filtered, n=audio.size)
+
+
+def _compress(band: np.ndarray, threshold_db: float, ratio: float) -> np.ndarray:
+    rms = np.sqrt(np.mean(np.square(band))) + 1e-9
+    rms_db = 20 * np.log10(rms)
+    if rms_db <= threshold_db:
+        return band
+    gain_db = threshold_db + (rms_db - threshold_db) / ratio - rms_db
+    gain = 10 ** (gain_db / 20)
+    return band * gain
+
+
+def multiband_compress(
+    audio: np.ndarray,
+    sr: int,
+    thresholds: tuple[float, float, float] = (-20.0, -20.0, -20.0),
+    ratios: tuple[float, float, float] = (2.0, 2.0, 2.0),
+) -> np.ndarray:
+    """Apply naive three-band compression to ``audio``.
+
+    Parameters
+    ----------
+    audio:
+        Mono audio signal.
+    sr:
+        Sample rate in Hz.
+    thresholds:
+        Thresholds in dB for low/mid/high bands.
+    ratios:
+        Compression ratios for the corresponding bands.
+    """
+
+    bands = []
+    for (low, high), th, ra in zip(BANDS, thresholds, ratios):
+        band = _bandpass(audio, sr, low, high)
+        band = _compress(band, th, ra)
+        bands.append(band)
+    return np.sum(bands, axis=0).astype(audio.dtype)
+
+
+__all__ = ["multiband_compress"]

--- a/mix_prep/noise_reduction.py
+++ b/mix_prep/noise_reduction.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Basic spectral noise reduction."""
+
+import numpy as np
+
+
+def spectral_gate(
+    audio: np.ndarray,
+    sr: int,
+    noise_threshold_db: float = -40.0,
+    reduction_db: float = 20.0,
+) -> np.ndarray:
+    """Attenuate frequency bins below ``noise_threshold_db``.
+
+    Parameters
+    ----------
+    audio:
+        Mono audio signal.
+    sr:
+        Sampling rate (present for API symmetry; not used).
+    noise_threshold_db:
+        Magnitude threshold in dB below which frequencies are considered noise.
+    reduction_db:
+        Amount of attenuation applied to noisy bins.
+    """
+
+    spectrum = np.fft.rfft(audio)
+    magnitude = np.abs(spectrum)
+    mag_db = 20 * np.log10(magnitude + 1e-9)
+    mask = mag_db < noise_threshold_db
+    spectrum[mask] *= 10 ** (-reduction_db / 20)
+    cleaned = np.fft.irfft(spectrum, n=audio.size)
+    return cleaned.astype(audio.dtype)
+
+
+__all__ = ["spectral_gate"]

--- a/mix_prep/stereo_imaging.py
+++ b/mix_prep/stereo_imaging.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Stereo imaging helpers."""
+
+import numpy as np
+
+
+def to_stereo(audio: np.ndarray) -> np.ndarray:
+    """Ensure ``audio`` has two channels by duplicating if necessary."""
+    if audio.ndim == 1:
+        return np.stack([audio, audio], axis=-1)
+    return audio
+
+
+def stereo_widen(audio: np.ndarray, width: float = 1.0) -> np.ndarray:
+    """Adjust stereo width using mid/side processing.
+
+    Parameters
+    ----------
+    audio:
+        Stereo (``n_samples, 2``) or mono (``n_samples``) array.
+    width:
+        Side gain factor. ``1`` leaves the signal unchanged, ``>1`` widens,
+        ``<1`` narrows.
+    """
+
+    stereo = to_stereo(audio)
+    mid = (stereo[:, 0] + stereo[:, 1]) / 2.0
+    side = (stereo[:, 0] - stereo[:, 1]) / 2.0
+    side *= width
+    left = mid + side
+    right = mid - side
+    return np.stack([left, right], axis=-1).astype(stereo.dtype)
+
+
+__all__ = ["stereo_widen", "to_stereo"]


### PR DESCRIPTION
## Summary
- Implement mix preparation modules for automatic EQ, compression, noise reduction, and stereo imaging
- Expand human mix workflow with reference analysis and effect chain helpers
- Replace mastering wrapper with CLI around `ai_master.master_track`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4cd2e599483269b457cd50200d773