### PR TITLE
Refine demo pipeline imports and helpers

### DIFF
--- a/examples/demo_pipeline.ipynb
+++ b/examples/demo_pipeline.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "32d83a97",
    "metadata": {},
    "source": [
     "# Demo Pipeline\n",
@@ -9,14 +10,15 @@
     "This notebook demonstrates a simple end-to-end audio workflow:\n",
     "1. **Generation** – create a starting track with `generation.suno_wrapper`.\n",
     "2. **Separation** – split the track into stems using `separation.demucs_wrapper`.\n",
-    "3. **Mix Prep** – organize stems for mixing with `mix_prep.mix_prep_wrapper`.\n",
-    "4. **Mastering** – finalize the mix with `mastering.mastering_wrapper`.\n",
+    "3. **Mix Prep** – organize and analyse stems with `mix_prep` utilities and `human_mix.reference_mixer`.\n",
+    "4. **Mastering** – finalize the mix with `mastering.ai_master`.\n",
     "\n",
     "The included code cells are placeholders; replace them with real implementations as the project evolves."
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "8bcbe71b",
    "metadata": {},
    "source": [
     "## Sample Audio\n",
@@ -31,35 +33,47 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "a143ada9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-13T01:50:33.191553Z",
+     "iopub.status.busy": "2025-09-13T01:50:33.191207Z",
+     "iopub.status.idle": "2025-09-13T01:50:33.441383Z",
+     "shell.execute_reply": "2025-09-13T01:50:33.440479Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "from generation import suno_wrapper\n",
-    "from separation import demucs_wrapper\n",
-    "from mix_prep import mix_prep_wrapper\n",
-    "from mastering import mastering_wrapper\n",
+    "from generation.suno_wrapper import generate_track\n",
+    "from separation.demucs_wrapper import separate\n",
+    "from mix_prep.mix_prep_wrapper import prepare_mix\n",
+    "from human_mix.reference_mixer import compare_to_reference\n",
+    "from mastering.ai_master import master_track\n",
     "\n",
     "# Step 1: Generation\n",
-    "generated = \"generated.wav\"\n",
-    "# suno_wrapper.generate_track(generated, prompt=\"lofi hiphop beat\")\n",
+    "generated = 'generated.wav'\n",
+    "# generate_track(generated, prompt='lofi hiphop beat')\n",
     "\n",
     "# Step 2: Separation\n",
-    "# stems_dir = demucs_wrapper.separate_stems(generated)\n",
+    "# stems_dir = separate(generated, 'stems')\n",
     "\n",
     "# For demonstration we'll reuse the sample file\n",
-    "stems_dir = \"stems/\"\n",
+    "stems_dir = 'stems/'\n",
     "\n",
-    "# Step 3: Mix Preparation\n",
-    "# mix_ready = mix_prep_wrapper.prepare_mix(stems_dir)\n",
+    "# Step 3: Mix Preparation (future implementation)\n",
+    "# mix_ready = prepare_mix(stems_dir)\n",
     "mix_ready = stems_dir\n",
     "\n",
+    "# Optional: compare to a reference track\n",
+    "# suggestions = compare_to_reference('reference.wav', {'mix': mix_ready})\n",
+    "\n",
     "# Step 4: Mastering\n",
-    "# master = mastering_wrapper.master_track(mix_ready)\n",
+    "# master_track(mix_ready, 'mastered.wav')\n",
     "master = mix_ready\n",
     "\n",
-    "print(\"Generated:\", generated)\n",
-    "print(\"Stems in:\", stems_dir)\n",
-    "print(\"Final master:\", master)\n"
+    "print('Generated:', generated)\n",
+    "print('Stems in:', stems_dir)\n",
+    "print('Final master:', master)\n"
    ]
   }
  ],
@@ -70,8 +84,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.x"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,

--- a/mix_prep/mix_prep_wrapper.py
+++ b/mix_prep/mix_prep_wrapper.py
@@ -1,3 +1,31 @@
-"""Placeholder for mix preparation routines."""
+"""Placeholder helpers for mix preparation steps.
 
-pass
+The real implementation will organise and clean up separated stems before they
+are sent to a mixing stage. For now, :func:`prepare_mix` simply returns the
+directory containing the stems so that higher-level workflows can be wired up
+without errors.
+"""
+
+from __future__ import annotations
+
+
+def prepare_mix(stems_dir: str) -> str:
+    """Prepare stems for mixing (stub).
+
+    Parameters
+    ----------
+    stems_dir:
+        Directory containing separated stems.
+
+    Returns
+    -------
+    str
+        The same ``stems_dir`` path for now.
+    """
+
+    # Future implementations might normalise levels, trim silence, etc.
+    return stems_dir
+
+
+__all__ = ["prepare_mix"]
+


### PR DESCRIPTION
## Summary
- Switch demo notebook to concrete helper functions: `generate_track`, `separate`, `prepare_mix`, `compare_to_reference`, and `master_track`
- Add stub `prepare_mix` helper for future mix-prep workflows
- Execute and clean demo notebook JSON to keep execution counts null

## Testing
- `PYTHONPATH=. pytest tests/test_midi.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4cd3c1d7c8326859551540f4201e9