### PR TITLE
Implement Demucs and Spleeter separation wrappers

### DIFF
--- a/separation/__init__.py
+++ b/separation/__init__.py
@@ -1,4 +1,13 @@
-"""Audio source separation utilities."""
+"""Audio source separation utilities.
+
+This module exposes thin wrappers around popular source separation
+backends.  Currently supported backends are:
+
+* ``demucs`` – requires the :mod:`demucs` package.
+* ``spleeter`` – requires the :mod:`spleeter` package.
+
+Use :func:`get_separator` to obtain a callable for the desired backend.
+"""
 
 from . import demucs_wrapper, spleeter_wrapper
 
@@ -9,7 +18,16 @@ def get_separator(backend: str = "demucs"):
     Parameters
     ----------
     backend: str
-        Name of the backend to use ("demucs" or "spleeter").
+        Name of the backend to use (``"demucs"`` or ``"spleeter"``).
+
+    Returns
+    -------
+    Callable
+        Function that performs separation on ``(input_path, output_dir)``.
+
+    Notes
+    -----
+    The chosen backend must have its optional dependency installed.
     """
     backend = backend.lower()
     if backend == "demucs":

--- a/separation/demucs_wrapper.py
+++ b/separation/demucs_wrapper.py
@@ -1,6 +1,53 @@
-"""Placeholder for Demucs source separation wrapper."""
+"""Demucs based source separation."""
+
+from __future__ import annotations
+
+from pathlib import Path
 
 
-def separate(input_path, output_dir):
-    """Separate audio into stems using Demucs (stub)."""
-    raise NotImplementedError("Demucs separation not implemented.")
+def separate(input_path: str | Path, output_dir: str | Path) -> Path:
+    """Separate audio into stems using `demucs`.
+
+    Parameters
+    ----------
+    input_path:
+        Path to the audio file to separate.
+    output_dir:
+        Directory where the separated stems will be written.
+
+    Returns
+    -------
+    pathlib.Path
+        Directory containing the separated stems.
+
+    Notes
+    -----
+    This function requires the optional :mod:`demucs` package.  A
+    :class:`ImportError` will be raised if it is not available.
+    """
+
+    try:
+        import demucs.separate as demucs_separate
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "Demucs is required for this separation backend. "
+            "Install it with `pip install demucs`."
+        ) from exc
+
+    input_path = Path(input_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Run Demucs separation using its CLI entry point.
+    # This mirrors running ``python -m demucs.separate``.
+    demucs_separate.main(["--out", str(output_dir), str(input_path)])
+
+    # Demucs creates ``<output_dir>/<model>/<track_name>``.  Return the
+    # directory containing the final stems if possible.
+    model_dirs = sorted(output_dir.iterdir())
+    if model_dirs:
+        stem_dir = model_dirs[0] / input_path.stem
+        if stem_dir.exists():
+            return stem_dir
+    return output_dir
+

--- a/separation/spleeter_wrapper.py
+++ b/separation/spleeter_wrapper.py
@@ -1,6 +1,47 @@
-"""Placeholder for Spleeter source separation wrapper."""
+"""Spleeter based source separation."""
+
+from __future__ import annotations
+
+from pathlib import Path
 
 
-def separate(input_path, output_dir):
-    """Separate audio into stems using Spleeter (stub)."""
-    raise NotImplementedError("Spleeter separation not implemented.")
+def separate(input_path: str | Path, output_dir: str | Path) -> Path:
+    """Separate audio into stems using `spleeter`.
+
+    Parameters
+    ----------
+    input_path:
+        Path to the audio file to separate.
+    output_dir:
+        Directory where the separated stems will be written.
+
+    Returns
+    -------
+    pathlib.Path
+        Directory containing the separated stems.
+
+    Notes
+    -----
+    This function requires the optional :mod:`spleeter` package.  A
+    :class:`ImportError` will be raised if it is not available.
+    """
+
+    try:
+        from spleeter.separator import Separator
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "Spleeter is required for this separation backend. "
+            "Install it with `pip install spleeter`."
+        ) from exc
+
+    input_path = Path(input_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use the default 2-stem configuration (vocals/accompaniment).
+    separator = Separator("spleeter:2stems")
+    separator.separate_to_file(str(input_path), str(output_dir))
+
+    stem_dir = output_dir / input_path.stem
+    return stem_dir if stem_dir.exists() else output_dir
+


### PR DESCRIPTION
## Summary
- add Demucs-based separation wrapper using `demucs.separate`
- add Spleeter-based separation wrapper using `Separator.separate_to_file`
- document available backends in separation module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4cf66a1e88326bacaf7de047dabd1