### PR TITLE
Use HDemucs model for audio upscaling

### DIFF
--- a/upscaling/guitar_upscaler.py
+++ b/upscaling/guitar_upscaler.py
@@ -1,20 +1,22 @@
 """Guitar track upscaling utilities.
 
-Model source: `StrumLift` – an imaginary model trained on studio guitar
-recordings hosted at https://example.com/models/strumlift.  The model expects
-stereo 48 kHz WAV files as input and produces an enhanced track at the same
-sample rate.
+The current implementation uses the pre-trained `HDemucs` source-separation
+network from :mod:`torchaudio` to extract and enhance the guitar stem from a
+mix.  Input audio must be stereo at 48 kHz; internally it is resampled to the
+model's native 44.1 kHz sample rate and the ``"other"`` stem is returned as the
+enhanced track.
 
-The module exposes a single :func:`enhance` function.  The current
-implementation loads the model and simply copies the input to the output path.
+The module exposes a single :func:`enhance` function.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-import shutil
 
-from .utils import load_model
+import torch
+import torchaudio
+
+from .utils import load_model, model_sample_rate
 
 _MODEL_NAME = "strumlift_v1"
 
@@ -25,9 +27,10 @@ def enhance(input_path: str | Path, output_path: str | Path) -> str:
     Parameters
     ----------
     input_path:
-        Path to a stereo 48 kHz WAV file containing the guitar track.
+        Path to a **stereo 48 kHz** WAV file containing the guitar track.
     output_path:
-        Destination path for the enhanced audio.
+        Destination path where the enhanced stereo audio will be written.  The
+        result is also at 48 kHz.
 
     Returns
     -------
@@ -35,6 +38,20 @@ def enhance(input_path: str | Path, output_path: str | Path) -> str:
         The ``output_path`` where the enhanced audio was saved.
     """
 
-    load_model(_MODEL_NAME)
-    shutil.copyfile(input_path, output_path)
+    model = load_model(_MODEL_NAME)
+    waveform, sr = torchaudio.load(str(input_path))
+    if sr != 48_000 or waveform.shape[0] != 2:
+        raise ValueError("Guitar enhancer expects stereo 48 kHz audio")
+
+    model_sr = model_sample_rate(_MODEL_NAME)
+    resampled = torchaudio.functional.resample(waveform, sr, model_sr)
+
+    with torch.no_grad():
+        sources = model(resampled.unsqueeze(0))
+
+    stem_index = model.sources.index("other")
+    guitar = sources[0, stem_index]
+
+    guitar = torchaudio.functional.resample(guitar, model_sr, sr)
+    torchaudio.save(str(output_path), guitar, sr)
     return str(output_path)

--- a/upscaling/utils.py
+++ b/upscaling/utils.py
@@ -1,8 +1,9 @@
 """Shared helpers for audio upscaling models.
 
-This module centralizes common functionality such as model loading.  The
-actual models are placeholders; in a real project these functions would load
-pre-trained neural networks from disk or download them on demand.
+This module centralises functionality used by the upscaling utilities such as
+downloading and instantiating pre-trained neural networks.  The helpers wrap
+``torchaudio`` pipelines so that individual upscalers only need to call
+``load_model`` and work with a regular :class:`torch.nn.Module`.
 """
 
 from __future__ import annotations
@@ -10,22 +11,69 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Any
 
+import torchaudio
+
+# Mapping from the public model names used by the modules to the corresponding
+# ``torchaudio`` bundle.  Both the guitar and vocal upscalers currently share
+# the same HDemucs model, but this dictionary makes it easy to swap out the
+# backend in the future.
+_MODEL_BUNDLES: dict[str, Any] = {
+    "strumlift_v1": torchaudio.pipelines.HDEMUCS_HIGH_MUSDB_PLUS,
+    "ultravox_v1": torchaudio.pipelines.HDEMUCS_HIGH_MUSDB_PLUS,
+}
+
 
 @lru_cache()
-def load_model(name: str) -> dict[str, Any]:
+def load_model(name: str):
     """Load and cache an upscaling model by name.
+
+    The first time a model is requested the corresponding weights are
+    downloaded via the :mod:`torchaudio` pipeline.  Subsequent calls reuse the
+    cached model instance.
 
     Parameters
     ----------
     name:
-        Identifier of the model to load.
+        Identifier of the model to load.  See :data:`_MODEL_BUNDLES`.
 
     Returns
     -------
-    dict[str, Any]
-        Placeholder object representing the loaded model.
+    torch.nn.Module
+        The instantiated model ready for inference.
+
+    Raises
+    ------
+    ValueError
+        If ``name`` does not correspond to a known model.
     """
 
-    # In this stub implementation we simply return a dictionary describing the
-    # model.  Real implementations would perform I/O here.
-    return {"model": name}
+    try:
+        bundle = _MODEL_BUNDLES[name]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"Unknown model '{name}'") from exc
+
+    return bundle.get_model().eval()
+
+
+def model_sample_rate(name: str) -> int:
+    """Return the sample rate expected by the given model."""
+
+    try:
+        bundle = _MODEL_BUNDLES[name]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"Unknown model '{name}'") from exc
+
+    return bundle.sample_rate
+
+
+def ensure_downloaded(name: str) -> None:
+    """Ensure that the model weights for ``name`` are downloaded.
+
+    This is a small convenience wrapper around :func:`load_model` that simply
+    triggers the download without returning the model.  It mirrors the
+    semantics of helpers in other parts of the codebase and is mainly provided
+    so that tests can prefetch weights if desired.
+    """
+
+    load_model(name)
+

--- a/upscaling/voc_upscaler.py
+++ b/upscaling/voc_upscaler.py
@@ -1,21 +1,22 @@
 """Vocal upscaling utilities.
 
-Model source: `UltraVox` – a fictional neural network for vocal enhancement
-available from https://example.com/models/ultravox.  The model expects mono
-44.1 kHz WAV files as input and outputs an enhanced version at the same sample
-rate.
+The implementation uses the same pre-trained `HDemucs` model as the guitar
+upscaler.  The network extracts the ``"vocals"`` stem from a mixture.  Inputs
+must be mono 44.1 kHz WAV files; the model operates on stereo audio so the
+single channel is duplicated prior to inference.
 
 The main entry point is :func:`enhance`, which loads the model and writes the
-processed audio to disk.  In this placeholder implementation the input file is
-simply copied to the destination.
+processed audio to disk.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-import shutil
 
-from .utils import load_model
+import torch
+import torchaudio
+
+from .utils import load_model, model_sample_rate
 
 _MODEL_NAME = "ultravox_v1"
 
@@ -26,9 +27,10 @@ def enhance(input_path: str | Path, output_path: str | Path) -> str:
     Parameters
     ----------
     input_path:
-        Path to a mono 44.1 kHz WAV file containing the vocals.
+        Path to a **mono 44.1 kHz** WAV file containing the vocals.
     output_path:
-        Destination path where the enhanced audio will be written.
+        Destination path where the enhanced audio will be written.  The result
+        is mono 44.1 kHz.
 
     Returns
     -------
@@ -36,6 +38,25 @@ def enhance(input_path: str | Path, output_path: str | Path) -> str:
         The ``output_path`` where the enhanced audio was saved.
     """
 
-    load_model(_MODEL_NAME)
-    shutil.copyfile(input_path, output_path)
+    model = load_model(_MODEL_NAME)
+    waveform, sr = torchaudio.load(str(input_path))
+    if sr != 44_100 or waveform.shape[0] != 1:
+        raise ValueError("Vocal enhancer expects mono 44.1 kHz audio")
+
+    model_sr = model_sample_rate(_MODEL_NAME)
+    if sr != model_sr:
+        waveform = torchaudio.functional.resample(waveform, sr, model_sr)
+        sr = model_sr
+
+    # HDemucs expects stereo input; duplicate the channel for processing.
+    stereo = waveform.repeat(2, 1)
+
+    with torch.no_grad():
+        sources = model(stereo.unsqueeze(0))
+
+    stem_index = model.sources.index("vocals")
+    vocals = sources[0, stem_index]
+
+    mono = vocals.mean(dim=0, keepdim=True)
+    torchaudio.save(str(output_path), mono, sr)
     return str(output_path)


### PR DESCRIPTION
## Summary
- replace placeholder upscalers with HDemucs-based enhancement for guitar and vocals
- document sample-rate and channel expectations
- add shared model loading utilities for download and sample rate queries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4cfea023483268bb50b4a249f5765