### PR TITLE
docs: update dependency lists and optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ pip install -r requirements.txt
 pip install .
 ```
 
-For optional machine learning features, install the extra dependencies:
+For optional machine learning features such as loudness normalisation or stem
+separation, install the extra dependencies:
 
 ```bash
 pip install .[ml]
 ```
 
-These heavier packages—`datasets`, `peft`, `transformers`, and `pyloudnorm`—are
-included in `requirements.txt` but can be skipped if you only need the core MIDI
+These heavier packages—`datasets`, `peft`, `transformers`, `pyloudnorm`,
+`demucs`, and `spleeter`—are collected under the `ml` extra and listed at the
+end of `requirements.txt`. They can be skipped if you only need the core MIDI
 utilities.
 
 ## Coding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "mido",
     "requests",
     "numpy",
+    "torch",
 ]
 
 [project.optional-dependencies]
@@ -23,6 +24,8 @@ ml = [
     "peft",
     "transformers",
     "pyloudnorm",
+    "demucs",
+    "spleeter",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,12 @@ soundfile
 mido
 requests
 numpy
+torch
 
 # Heavy ML dependencies (optional)
 datasets
 peft
 transformers
 pyloudnorm
+demucs
+spleeter


### PR DESCRIPTION
## Summary
- add torch to core dependencies
- list demucs and spleeter as optional ML extras
- document optional ML dependencies in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d2175e2c832686422144f45c5af6