### PR TITLE
Add tests for mix prep, mastering, and separation

### DIFF
--- a/tests/test_mastering.py
+++ b/tests/test_mastering.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+from mastering import master_track
+
+
+def test_master_track_creates_file_and_changes_loudness(tmp_path: Path):
+    sr = 22050
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = 0.1 * np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    input_path = tmp_path / "in.wav"
+    output_path = tmp_path / "out.wav"
+    sf.write(input_path, audio, sr)
+    master_track(input_path, output_path, target_lufs=-14.0)
+    assert output_path.exists()
+    original, _ = sf.read(input_path)
+    mastered, _ = sf.read(output_path)
+    orig_rms = np.sqrt(np.mean(original**2))
+    new_rms = np.sqrt(np.mean(mastered**2))
+    assert new_rms > orig_rms

--- a/tests/test_mix_prep.py
+++ b/tests/test_mix_prep.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from mix_prep.auto_eq import auto_eq
+from mix_prep.multiband_compression import multiband_compress
+from mix_prep.stereo_imaging import stereo_widen
+
+
+def _band_energy(audio: np.ndarray, sr: int, low: float, high: float) -> float:
+    spec = np.fft.rfft(audio)
+    freqs = np.fft.rfftfreq(audio.size, 1.0 / sr)
+    mask = (freqs >= low) & (freqs < high)
+    return np.mean(np.abs(spec[mask]))
+
+
+def test_auto_eq_balances_spectrum():
+    sr = 44100
+    rng = np.random.default_rng(0)
+    noise = rng.standard_normal(sr)
+    spec = np.fft.rfft(noise)
+    freqs = np.fft.rfftfreq(noise.size, 1.0 / sr)
+    spec[freqs > 2000] *= 0.1  # dull high end
+    dull = np.fft.irfft(spec, n=noise.size)
+    processed = auto_eq(dull, sr)
+    before = _band_energy(dull, sr, 4000, 8000) / _band_energy(dull, sr, 20, 2000)
+    after = _band_energy(processed, sr, 4000, 8000) / _band_energy(processed, sr, 20, 2000)
+    assert after > before
+
+
+def test_multiband_compress_reduces_level():
+    sr = 44100
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 100 * t).astype(np.float32)
+    compressed = multiband_compress(
+        audio,
+        sr,
+        thresholds=(-30.0, -30.0, -30.0),
+        ratios=(10.0, 1.0, 1.0),
+    )
+    orig_rms = np.sqrt(np.mean(audio**2))
+    new_rms = np.sqrt(np.mean(compressed**2))
+    assert new_rms < orig_rms
+
+
+def test_stereo_widen_controls_side_energy():
+    rng = np.random.default_rng(1)
+    audio = rng.standard_normal((1000, 2)).astype(np.float32)
+    mono = stereo_widen(audio, width=0.0)
+    assert np.allclose(mono[:, 0], mono[:, 1])
+    widened = stereo_widen(audio, width=2.0)
+    orig_diff = np.mean((audio[:, 0] - audio[:, 1]) ** 2)
+    new_diff = np.mean((widened[:, 0] - widened[:, 1]) ** 2)
+    assert new_diff > orig_diff

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import separation
+
+
+def test_get_separator_demucs(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_separate(input_path, output_dir):
+        called["called"] = True
+        return Path(output_dir)
+
+    monkeypatch.setattr(separation.demucs_wrapper, "separate", fake_separate)
+    separator = separation.get_separator("demucs")
+    result = separator("in.wav", tmp_path)
+    assert called.get("called") is True
+    assert result == Path(tmp_path)
+
+
+def test_get_separator_spleeter(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_separate(input_path, output_dir):
+        called["called"] = True
+        return Path(output_dir)
+
+    monkeypatch.setattr(separation.spleeter_wrapper, "separate", fake_separate)
+    separator = separation.get_separator("spleeter")
+    result = separator("in.wav", tmp_path)
+    assert called.get("called") is True
+    assert result == Path(tmp_path)


### PR DESCRIPTION
## Summary
- Add coverage for mix preparation utilities: auto EQ, multiband compression, and stereo widening
- Smoke test mastering to ensure output file creation and loudness adjustment
- Mock Demucs and Spleeter separation backends to verify factory selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d217e578832685986a632e9d13fa