### PR TITLE
Stage 1.5 ML-ready architecture for Creative Audio Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ pip install -e .
 Optional extras layer on top as needed:
 
 ```bash
-pip install -e ".[app]"   # Streamlit UI
-pip install -e ".[dev]"   # pytest, ruff
-pip install -e ".[audio]" # librosa, soundfile, pyloudnorm, demucs, spleeter, torchaudio
-pip install -e ".[ml]"    # torch, transformers, scikit-learn, datasets (future ML work)
+pip install -e ".[app]"      # Streamlit UI
+pip install -e ".[dev]"      # pytest, ruff
+pip install -e ".[audio]"    # librosa, soundfile, pyloudnorm, demucs, spleeter, torchaudio
+pip install -e ".[ml]"       # torch, transformers, scikit-learn, datasets (future ML work)
+pip install -e ".[symbolic]" # miditok, symusic (optional MidiTok REMI tokenization)
 ```
 
 None of `torch`, `torchaudio`, `transformers`, `demucs`, `spleeter`, or
@@ -121,7 +122,13 @@ src/creative_audio_lab/
         arrangement.py             Combines the above + assigns GM instrument programs
     export/midi_export.py           Note events -> MIDI bytes (full arrangement + stems)
     evaluation/metrics.py           Note density, harmonic fit, novelty, scale adherence, ...
-    data/                           Dataset manifest + local-only MIDI loader + preprocessing
+    models/                         GenerationBackend interface, DeterministicBackend (default),
+                                    placeholder Text2midi / MIDI-LLM adapters
+    tokenization/                   Dependency-free REMI-style symbolic tokenizer
+                                    + optional MidiTok/symusic adapter
+    preview/                        MIDI summaries and piano-roll grids (data only, no audio)
+    data/                           Dataset manifest + provenance/license validation +
+                                    local-only MIDI loader + preprocessing
                                     (scaffolding for ML_ROADMAP.md — no auto-download)
 tests/                              One test module per component above
 docs/
@@ -156,6 +163,43 @@ produces the same arrangement. The pipeline is:
    cinematic, dance) per bar, chosen from style and energy.
 6. **Arrangement** — combines all four parts, picks General MIDI program
    numbers from the requested instrument set, and hands off to `export/`.
+
+## Stage 1.5: ML-ready architecture
+
+The generator is still deterministic, but the codebase now has the
+scaffolding a text-conditioned symbolic model needs — implemented and
+tested, without pretending a model is already trained:
+
+- **Tokenization layer** (`creative_audio_lab.tokenization`) — a
+  dependency-free, REMI-style tokenizer converts `Note` events to and from
+  flat symbolic token sequences (`BAR`/`POSITION`/`NOTE_ON`/`DURATION`/
+  `VELOCITY`/`TEMPO`/`PROGRAM`/`TIME_SIGNATURE`). An optional adapter wraps
+  [MidiTok](https://github.com/Natooz/MidiTok) REMI for tokenizing external
+  MIDI files (`pip install -e ".[symbolic]"`); without the extra it fails
+  with a clear install hint instead of an obscure import error.
+- **Dataset provenance registry** (`creative_audio_lab.data`) — dataset
+  manifest entries now carry source URL, license, commercial-use and
+  attribution flags, notes, and tags, with validation that errors on
+  missing licenses/sources and on fan-archive/unclear-rights material, and
+  warns on unverified commercial terms. See
+  [`examples/dataset_manifest.example.json`](examples/dataset_manifest.example.json)
+  (placeholder paths only — nothing is ever downloaded).
+- **Backend interface** (`creative_audio_lab.models`) — a
+  `GenerationBackend` ABC with `DeterministicBackend` (the current parser +
+  generators) as the default implementation the app now calls.
+- **Future model adapters** — `Text2MidiAdapter` and `MidiLlmAdapter` are
+  scaffolded behind the same interface; they report themselves unavailable
+  and raise `NotImplementedError` with concrete integration guidance.
+- **Preview layer** (`creative_audio_lab.preview`) — per-track summaries
+  (note counts, pitch range, bars, density, drum presence) and a
+  piano-roll grid data structure, all pure data with no audio rendering.
+
+Why still no trained model? Because training one properly requires a
+rights-cleared corpus (see [`docs/DATASETS.md`](docs/DATASETS.md)), a
+tokenization scheme that's already settled (this layer), and a baseline to
+beat (the deterministic generator plus `evaluation.metrics`). Stage 1.5
+puts those prerequisites in place so a model can be added honestly — not
+bolted on. See [`docs/ML_ROADMAP.md`](docs/ML_ROADMAP.md).
 
 ## MIDI Motif Lab
 

--- a/app.py
+++ b/app.py
@@ -20,10 +20,11 @@ import streamlit as st
 
 from creative_audio_lab.evaluation import evaluate_arrangement
 from creative_audio_lab.export import export_arrangement_files
-from creative_audio_lab.generators.arrangement import build_arrangement
+from creative_audio_lab.models import DEFAULT_BACKEND_NAME, get_backend, list_backends
 from creative_audio_lab.motif_detection import detect_motifs
 from creative_audio_lab.music_theory import SCALES
-from creative_audio_lab.prompt_parser import STYLE_PRESETS, parse_prompt
+from creative_audio_lab.preview import summarize_arrangement
+from creative_audio_lab.prompt_parser import STYLE_PRESETS
 
 EXAMPLE_PROMPTS = [
     "dark orchestral boss battle theme, 140 BPM, brass ostinato, strings, piano arps",
@@ -52,7 +53,32 @@ st.caption(
 if "prompt_text" not in st.session_state:
     st.session_state["prompt_text"] = ""
 
+backend_infos = list_backends()
+available_backends = [info for info in backend_infos if info.available]
+future_backends = [info for info in backend_infos if not info.available]
+
 with st.sidebar:
+    st.header("Backend")
+    backend_labels = {info.display_name: info.name for info in available_backends}
+    backend_label = st.selectbox("Generation backend", list(backend_labels))
+    backend_name = backend_labels.get(backend_label, DEFAULT_BACKEND_NAME)
+    for info in future_backends:
+        st.caption(f"🔒 **{info.display_name}** — scaffolded, not yet available")
+    with st.expander("ML readiness"):
+        st.markdown(
+            "- The **deterministic backend** (rule-based parser + generators) is the "
+            "current default — no trained model is involved.\n"
+            "- A **symbolic tokenization layer** (`creative_audio_lab.tokenization`) "
+            "converts note events to/from REMI-style tokens, with an optional MidiTok "
+            "adapter.\n"
+            "- A **dataset manifest + provenance layer** (`creative_audio_lab.data`) "
+            "tracks source, license, and commercial-use rights before any training data "
+            "is touched.\n"
+            "- **Future model adapters** (Text2midi, MIDI-LLM) are scaffolded behind the "
+            "same `GenerationBackend` interface, so a learned model can plug in without "
+            "changing this app."
+        )
+
     st.header("Controls")
     st.caption("Leave a control on Auto to let the deterministic prompt parser decide.")
     key_choice = st.selectbox("Key", ["Auto", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"])
@@ -82,7 +108,8 @@ if generate:
     if not prompt.strip():
         st.warning("Enter a prompt first.")
     else:
-        controls = parse_prompt(
+        backend = get_backend(backend_name)
+        arrangement = backend.generate(
             prompt,
             key=None if key_choice == "Auto" else key_choice,
             mode=None if mode_choice == "Auto" else mode_choice,
@@ -93,12 +120,11 @@ if generate:
             density=None if density_choice == "Auto" else density_choice,
             instruments=instruments_choice or None,
         )
-        st.session_state["controls"] = controls
-        st.session_state["arrangement"] = build_arrangement(controls)
+        st.session_state["arrangement"] = arrangement
 
 if "arrangement" in st.session_state:
     arrangement = st.session_state["arrangement"]
-    controls = st.session_state["controls"]
+    controls = arrangement.controls
 
     st.subheader("Arrangement summary")
     summary_cols = st.columns(4)
@@ -117,6 +143,22 @@ if "arrangement" in st.session_state:
     degrees = [str(event.chord.degree) for event in arrangement.chord_events]
     shown = " – ".join(degrees[:16]) + (" ..." if len(degrees) > 16 else "")
     st.write(f"**Chord progression (scale degrees):** {shown}")
+
+    summary = summarize_arrangement(arrangement)
+    with st.expander("Track summary"):
+        st.table(
+            [
+                {
+                    "Track": track.name,
+                    "Program": "GM drums" if track.is_drum else (track.program if track.program is not None else "—"),
+                    "Notes": track.note_count,
+                    "Bars": track.duration_bars,
+                    "Pitch range": "—" if track.pitch_min is None or track.is_drum else f"{track.pitch_min}–{track.pitch_max}",
+                    "Notes/bar": f"{track.notes_per_bar:.1f}",
+                }
+                for track in summary.tracks
+            ]
+        )
 
     st.subheader("Download MIDI")
     files = export_arrangement_files(arrangement)

--- a/docs/DATASETS.md
+++ b/docs/DATASETS.md
@@ -10,6 +10,14 @@ around.
 `midi_dataset_loader.load_dataset_notes` reads MIDI files you've already
 placed on disk. Neither one reaches out to the network.
 
+Since Stage 1.5, every manifest entry carries a provenance record (source
+URL, license, commercial-use and attribution flags, tags), and
+`creative_audio_lab.data.provenance.validate_entry` flags entries with
+missing licenses or sources, unverified commercial terms, or
+fan-archive/unclear-rights tags **before** they can reach any training
+pipeline. See `examples/dataset_manifest.example.json` for a template
+(placeholder paths only).
+
 ## Recommended datasets for future ML work
 
 | Dataset | What it offers | Licensing notes |
@@ -18,12 +26,27 @@ placed on disk. Neither one reaches out to the network.
 | **[POP909](https://github.com/music-x-lab/POP909-Dataset)** | 909 pop songs with melody, chord, and accompaniment-arrangement structure. Good for the melody/chord/arrangement split this project already models. | Research use; underlying songs are copyrighted commercial works. Do not redistribute audio, and confirm terms before any commercial use of derived models. |
 | **[GiantMIDI-Piano](https://github.com/bytedance/GiantMIDI-Piano)** | ~10,000 transcribed classical piano pieces. Useful for larger-scale symbolic pretraining. | Transcriptions are largely of public-domain classical works, but verify each source recording's rights before use — the transcription process itself doesn't clear licensing on the underlying audio. |
 | **[Lakh MIDI Dataset](https://colinraffel.com/projects/lmd/)** | ~176,000 MIDI files matched to the Million Song Dataset; broad genre coverage. | Mixed provenance and heavy duplication. Only usable with careful deduplication, and only for the subset whose licensing has actually been checked — do not train on it in bulk without review. |
+| **[MidiCaps](https://huggingface.co/datasets/amaai-lab/MidiCaps)** | ~168k MIDI files paired with rich text captions — the natural training pair for text-conditioned symbolic generation (Text2midi was trained on it). | Captions/metadata are CC BY-SA 4.0, but the MIDI itself comes from Lakh, so Lakh's mixed-provenance caveats apply to the note content. |
+| **[MetaScore (public subset)](https://github.com/salu133445/metascore)** | MuseScore-derived scores with genre tags and user descriptions; the public subset is restricted to permissively licensed scores. | Rights vary per score — use only the CC-licensed public subset and record each score's individual license. |
+| **[Slakh2100](http://www.slakh.com/)** | 2100 multi-track MIDI arrangements with professionally synthesized audio stems; good for multi-instrument arrangement modelling. | CC BY 4.0 for the redistributed set — attribution required. |
+| **[ComMU](https://github.com/POZAlabs/ComMU-code)** | ~11k short MIDI samples by professional composers, each with 12 metadata fields (BPM, key, chord progression, track role, ...) — very close to this project's `GenerationControls` framing. | CC BY-NC 4.0 — non-commercial only. |
+| **[EMOPIA](https://annahung31.github.io/EMOPIA/)** | ~1k pop-piano clips with valence/arousal emotion labels; useful for mood conditioning. | CC BY-NC-SA 4.0, and the clips are transcriptions of copyrighted pop covers — non-commercial, underlying works remain copyrighted. |
+| **[Aria-MIDI](https://github.com/EleutherAI/aria)** | ~1M piano MIDI transcriptions from public performance recordings; large-scale symbolic pretraining material. | Verify the release license at source before use — transcription does not clear rights on the underlying recordings; treat commercial use as unresolved. |
+| **[music21 corpus](https://www.music21.org/music21docs/about/referenceCorpus.html)** | Curated symbolic corpus bundled with music21 (Bach chorales, folk songs, ...); small, clean, mostly public domain. | music21 itself is BSD; corpus works are mostly public domain but a few carry their own restrictions — check per work. |
+
+These are also registered (with the same provenance fields) in
+`creative_audio_lab.data.dataset_manifest.RECOMMENDED_DATASETS`.
 
 ## Hard rules
 
 - **Do not train on random copyrighted game or anime MIDI packs** scraped
   from fan sites without checking rights. "I found it on a forum" is not a
   license.
+- **Fan OST / game MIDI archives are private reference and evaluation
+  material only** — listening, analysis, sanity-checking metrics — unless
+  they are properly licensed for training. Tag such entries
+  `"fan-archive"` (or `"unclear-rights"`) in the manifest;
+  `provenance.validate_entry` will refuse to consider them training-ready.
 - **Do not claim style cloning of living artists or copyrighted
   franchises.** This project's prompt vocabulary (see `prompt_parser.py`)
   deliberately uses generic descriptors instead of naming artists or IP.
@@ -37,7 +60,12 @@ placed on disk. Neither one reaches out to the network.
 1. Source the MIDI files yourself and place them in a local directory —
    nothing here fetches them for you.
 2. Describe them with a manifest (see `DatasetEntry` in
-   `creative_audio_lab/data/dataset_manifest.py`) noting the source, URL,
-   and license notes above.
-3. Use `creative_audio_lab.data.midi_dataset_loader.load_dataset_notes` to
+   `creative_audio_lab/data/dataset_manifest.py`, and
+   `examples/dataset_manifest.example.json` for the JSON shape): name,
+   source URL, license, commercial-use/attribution flags, notes, and tags.
+3. Run the entries through
+   `creative_audio_lab.data.provenance.validate_manifest` and resolve every
+   error (and ideally every warning) before using them for anything
+   training-related.
+4. Use `creative_audio_lab.data.midi_dataset_loader.load_dataset_notes` to
    parse the directory into `Note` events for feature extraction.

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -19,11 +19,44 @@ A rule-based baseline is:
 - **Immediately shippable.** No training data, GPUs, or model hosting
   required — the whole app extra is `mido` + `numpy` + `streamlit`.
 
+## Stage 1.5 — ML readiness (implemented)
+
+Between the deterministic baseline and any actual training sits a layer of
+infrastructure that has to exist first. It's implemented now:
+
+- **Symbolic tokenization** (`creative_audio_lab.tokenization`): a
+  dependency-free REMI-style tokenizer maps `Note` events to and from flat
+  token sequences — the representation a symbolic sequence model trains
+  on. [MidiTok](https://github.com/Natooz/MidiTok) and
+  [symusic](https://github.com/Yikai-Liao/symusic) are supported as an
+  *optional* extra (`pip install -e ".[symbolic]"`) for tokenizing external
+  MIDI files with the reference REMI implementation; they are candidate
+  future preprocessing dependencies, not core requirements.
+- **Dataset provenance** (`creative_audio_lab.data.provenance`,
+  `.license_policy`): manifest entries carry source URL, license,
+  commercial-use/attribution flags, and tags, and validation refuses
+  fan-archive/unclear-rights material before it can reach a training
+  corpus.
+- **Backend interface** (`creative_audio_lab.models`): the app now
+  generates through a `GenerationBackend` abstraction.
+  `DeterministicBackend` wraps the existing parser + generators and remains
+  the default. `Text2MidiAdapter` and `MidiLlmAdapter` are placeholder
+  adapters marking where learned models plug in —
+  [Text2midi](https://github.com/AMAAI-Lab/Text2midi)-style
+  caption-conditioned transformers and MIDI-token LLMs are *candidate
+  future integration baselines*, not current dependencies; the adapters
+  import nothing heavy and raise `NotImplementedError` with integration
+  guidance.
+- **Preview/analysis** (`creative_audio_lab.preview`): track summaries and
+  piano-roll grids give both the app and future dataset tooling an
+  inspectable, dependency-light view of any note content.
+
 ## Planned progression
 
 1. **Dataset ingestion** — point `creative_audio_lab.data.midi_dataset_loader`
    at a local directory of MIDI files (see `DATASETS.md` for sourcing and
-   licensing guidance). Nothing is downloaded automatically.
+   licensing guidance), registered through the dataset manifest and passed
+   through provenance validation. Nothing is downloaded automatically.
 2. **MIDI parsing into note events** — already implemented in
    `creative_audio_lab.midi_parser`; reused unchanged by the training
    pipeline so generation and training share one canonical `Note`
@@ -48,8 +81,11 @@ A rule-based baseline is:
    vocabulary, as a stepping stone before a full neural model and a much
    stronger baseline to evaluate against.
 8. **Transformer-based symbolic MIDI generation** — a sequence model over
-   tokenized note events (pitch, duration, velocity, rest) trained on the
-   ingested corpus, generating full parts rather than just continuations.
+   tokenized note events trained on the ingested corpus, generating full
+   parts rather than just continuations. The Stage 1.5 tokenization layer
+   (internal REMI-style tokenizer, optional MidiTok/symusic) defines the
+   vocabulary; the Stage 1.5 backend adapters define where the model plugs
+   into the app.
 9. **Conditional generation** — condition the transformer on key, tempo,
    mood, genre, instrument set, and an optional seed motif, so prompts and
    UI controls steer generation the same way they do today.

--- a/examples/dataset_manifest.example.json
+++ b/examples/dataset_manifest.example.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "my-cc0-piano-set",
+    "source_url": "https://example.org/open-piano-midi",
+    "license": "CC0 1.0",
+    "local_path": "/data/midi/cc0_piano",
+    "commercial_use_allowed": true,
+    "attribution_required": false,
+    "description": "Example entry: a hypothetical CC0 piano MIDI collection. Path is a placeholder — nothing is downloaded automatically.",
+    "notes": "Fully cleared for training and commercial use.",
+    "tags": ["piano", "example"]
+  },
+  {
+    "name": "research-pop-arrangements",
+    "source_url": "https://example.org/research-pop-midi",
+    "license": "CC BY-NC-SA 4.0",
+    "local_path": "/data/midi/research_pop",
+    "commercial_use_allowed": false,
+    "attribution_required": true,
+    "description": "Example entry: a hypothetical research-licensed pop arrangement set.",
+    "notes": "Non-commercial research use only; attribute the source in any publication.",
+    "tags": ["pop", "example"]
+  },
+  {
+    "name": "old-forum-game-midi-pack",
+    "source_url": "",
+    "license": "",
+    "local_path": "/data/midi/forum_pack",
+    "commercial_use_allowed": null,
+    "attribution_required": null,
+    "description": "Example entry showing what provenance validation rejects: no source URL, no license, fan-archive material.",
+    "notes": "Private reference/listening only — must NOT be used for training. validate_entry flags this with errors.",
+    "tags": ["fan-archive", "example"]
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,13 @@ ml = [
     "scikit-learn",
     "datasets",
 ]
+# Optional symbolic-tokenization stack (Stage 1.5). The internal tokenizer in
+# creative_audio_lab.tokenization needs none of these — they only power the
+# MidiTok REMI adapter for tokenizing external MIDI files.
+symbolic = [
+    "miditok",
+    "symusic",
+]
 
 [project.scripts]
 ai-master = "mastering.ai_master:main"
@@ -49,6 +56,9 @@ packages = [
     "creative_audio_lab.export",
     "creative_audio_lab.evaluation",
     "creative_audio_lab.data",
+    "creative_audio_lab.tokenization",
+    "creative_audio_lab.models",
+    "creative_audio_lab.preview",
     "midi",
     "separation",
     "mix_prep",

--- a/src/creative_audio_lab/data/__init__.py
+++ b/src/creative_audio_lab/data/__init__.py
@@ -1,7 +1,35 @@
 """Dataset scaffolding for the future ML roadmap (see docs/ML_ROADMAP.md).
 
-Nothing in this package downloads data automatically. It only defines a
-manifest schema, a loader for MIDI files the user has already placed on
-disk, and a few preprocessing primitives that a future training pipeline
-would build on.
+Nothing in this package downloads data automatically. It defines a
+manifest schema (:mod:`.dataset_manifest`), provenance and license-policy
+validation (:mod:`.provenance`, :mod:`.license_policy`), a loader for MIDI
+files the user has already placed on disk (:mod:`.midi_dataset_loader`),
+and preprocessing primitives (:mod:`.preprocess_midi`) that a future
+training pipeline would build on.
 """
+
+from .dataset_manifest import RECOMMENDED_DATASETS, DatasetEntry, entry_from_dict, load_manifest
+from .license_policy import LicenseAssessment, assess_license, check_entry_license, normalize_license
+from .provenance import (
+    ProvenanceIssue,
+    assert_training_ready,
+    has_errors,
+    validate_entry,
+    validate_manifest,
+)
+
+__all__ = [
+    "DatasetEntry",
+    "RECOMMENDED_DATASETS",
+    "entry_from_dict",
+    "load_manifest",
+    "LicenseAssessment",
+    "assess_license",
+    "check_entry_license",
+    "normalize_license",
+    "ProvenanceIssue",
+    "assert_training_ready",
+    "has_errors",
+    "validate_entry",
+    "validate_manifest",
+]

--- a/src/creative_audio_lab/data/dataset_manifest.py
+++ b/src/creative_audio_lab/data/dataset_manifest.py
@@ -1,55 +1,203 @@
 """Schema and recommended entries for future ML training datasets.
 
 This module never downloads anything — see docs/DATASETS.md for licensing
-and usage guidance on each recommended dataset.
+and usage guidance on each recommended dataset, and
+``examples/dataset_manifest.example.json`` for a manifest template using
+placeholder paths.
+
+Provenance/rights validation lives in
+:mod:`creative_audio_lab.data.provenance` and
+:mod:`creative_audio_lab.data.license_policy`.
 """
 
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
-from typing import List, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 
 @dataclass(frozen=True)
 class DatasetEntry:
-    """Describes one dataset a future training pipeline could ingest."""
+    """Describes one dataset a future training pipeline could ingest.
+
+    Attributes
+    ----------
+    name:
+        Human-readable dataset name.
+    source_url:
+        Where the dataset officially comes from. Required for a clean
+        provenance record — "found on a forum" is not a source.
+    license:
+        License identifier or short statement (e.g. ``"CC BY-NC-SA 4.0"``,
+        ``"research-only"``, ``"unknown"``).
+    local_path:
+        Where the user has placed the files locally, if at all. Nothing is
+        ever downloaded automatically.
+    commercial_use_allowed:
+        ``True``/``False`` when the license makes it clear; ``None`` when
+        unknown or unverified (validation warns on ``None``).
+    attribution_required:
+        Whether the license requires crediting the source; ``None`` = unknown.
+    description:
+        What the dataset contains and why it's useful.
+    notes:
+        Free-form rights/usage caveats (deduplication needs, per-file
+        license checks, ...).
+    tags:
+        Free-form labels. Tags like ``"fan-archive"`` or
+        ``"unclear-rights"`` mark a dataset as private reference/evaluation
+        only — provenance validation flags them as unusable for training.
+    """
 
     name: str
-    description: str
-    url: str
-    license_notes: str
-    local_path: str | None = None
+    source_url: str = ""
+    license: str = ""
+    local_path: Optional[str] = None
+    commercial_use_allowed: Optional[bool] = None
+    attribution_required: Optional[bool] = None
+    description: str = ""
+    notes: str = ""
+    tags: Tuple[str, ...] = ()
+
+
+_ENTRY_FIELDS = {f.name for f in fields(DatasetEntry)}
+
+
+def entry_from_dict(raw: Dict[str, Any]) -> DatasetEntry:
+    """Build a :class:`DatasetEntry` from a plain dict (e.g. one JSON manifest item).
+
+    Raises
+    ------
+    ValueError
+        If the dict is missing ``name`` or contains unknown keys, so typos
+        in manifest files fail loudly instead of silently dropping rights
+        metadata.
+    """
+    unknown = set(raw) - _ENTRY_FIELDS
+    if unknown:
+        raise ValueError(
+            f"Unknown dataset-manifest keys {sorted(unknown)}; expected a subset of {sorted(_ENTRY_FIELDS)}"
+        )
+    if "name" not in raw:
+        raise ValueError("Every dataset-manifest entry needs a 'name'")
+    data = dict(raw)
+    if "tags" in data and data["tags"] is not None:
+        data["tags"] = tuple(data["tags"])
+    return DatasetEntry(**data)
 
 
 RECOMMENDED_DATASETS: List[DatasetEntry] = [
     DatasetEntry(
         name="MAESTRO",
+        source_url="https://magenta.tensorflow.org/datasets/maestro",
+        license="CC BY-NC-SA 4.0",
+        commercial_use_allowed=False,
+        attribution_required=True,
         description="Expressive solo piano performances aligned to MIDI, from the International Piano-e-Competition.",
-        url="https://magenta.tensorflow.org/datasets/maestro",
-        license_notes="CC BY-NC-SA 4.0. Non-commercial use only unless a separate license is obtained.",
+        notes="Non-commercial use only unless a separate license is obtained.",
+        tags=("piano", "performance"),
     ),
     DatasetEntry(
         name="POP909",
+        source_url="https://github.com/music-x-lab/POP909-Dataset",
+        license="research-only",
+        commercial_use_allowed=False,
         description="909 pop songs with aligned melody, chords, and accompaniment arrangement structure.",
-        url="https://github.com/music-x-lab/POP909-Dataset",
-        license_notes="Research use; underlying songs are copyrighted commercial works — do not redistribute audio, "
+        notes="Underlying songs are copyrighted commercial works — do not redistribute audio, "
         "and confirm terms before any commercial use of derived models.",
+        tags=("pop", "melody-chord-split"),
     ),
     DatasetEntry(
         name="GiantMIDI-Piano",
+        source_url="https://github.com/bytedance/GiantMIDI-Piano",
+        license="unknown",
         description="Large-scale transcribed classical piano MIDI (~10k pieces) for symbolic modelling at scale.",
-        url="https://github.com/bytedance/GiantMIDI-Piano",
-        license_notes="Transcriptions of largely public-domain classical works; verify each source recording's rights "
+        notes="Transcriptions of largely public-domain classical works; verify each source recording's rights "
         "before use, as transcription source audio may carry its own license.",
+        tags=("piano", "classical", "transcription"),
     ),
     DatasetEntry(
         name="Lakh MIDI Dataset",
+        source_url="https://colinraffel.com/projects/lmd/",
+        license="unknown",
         description="~176k MIDI files matched to Million Song Dataset entries; broad genre coverage.",
-        url="https://colinraffel.com/projects/lmd/",
-        license_notes="Mixed provenance and heavy duplication. Only usable with careful deduplication, and only for "
+        notes="Mixed provenance and heavy duplication. Only usable with careful deduplication, and only for "
         "entries whose licensing has been individually checked — do not train on this in bulk without review.",
+        tags=("multi-genre", "unclear-rights"),
+    ),
+    DatasetEntry(
+        name="MidiCaps",
+        source_url="https://huggingface.co/datasets/amaai-lab/MidiCaps",
+        license="CC BY-SA 4.0 (captions/metadata)",
+        description="~168k MIDI files paired with rich text captions — the natural fit for "
+        "text-conditioned symbolic generation.",
+        notes="Captions are CC BY-SA, but the MIDI comes from the Lakh MIDI Dataset, so Lakh's "
+        "mixed-provenance caveats apply to the note content itself.",
+        tags=("text-to-midi", "captions"),
+    ),
+    DatasetEntry(
+        name="MetaScore (public subset)",
+        source_url="https://github.com/salu133445/metascore",
+        license="per-score (CC-licensed subset)",
+        description="MuseScore-derived scores with rich metadata (genre, tags, user descriptions); "
+        "the public subset is restricted to permissively licensed scores.",
+        notes="Rights vary per score — filter to the CC-licensed public subset and record each score's license.",
+        tags=("scores", "metadata"),
+    ),
+    DatasetEntry(
+        name="Slakh2100",
+        source_url="http://www.slakh.com/",
+        license="CC BY 4.0",
+        commercial_use_allowed=True,
+        attribution_required=True,
+        description="2100 multi-track MIDI arrangements (from Lakh) with professionally synthesized audio stems.",
+        notes="Useful for multi-instrument arrangement modelling; the redistributed set is CC BY 4.0.",
+        tags=("multi-track", "stems"),
+    ),
+    DatasetEntry(
+        name="ComMU",
+        source_url="https://github.com/POZAlabs/ComMU-code",
+        license="CC BY-NC 4.0",
+        commercial_use_allowed=False,
+        attribution_required=True,
+        description="~11k short MIDI samples written by professional composers, each labelled with 12 metadata "
+        "fields (BPM, key, chord progression, instrument, track role, ...).",
+        notes="Purpose-built for controllable/conditioned generation — very close to this project's "
+        "GenerationControls framing. Non-commercial.",
+        tags=("conditioned-generation", "metadata"),
+    ),
+    DatasetEntry(
+        name="EMOPIA",
+        source_url="https://annahung31.github.io/EMOPIA/",
+        license="CC BY-NC-SA 4.0",
+        commercial_use_allowed=False,
+        attribution_required=True,
+        description="~1k pop-piano clips with per-clip emotion (valence/arousal quadrant) labels.",
+        notes="Clips are transcriptions of copyrighted pop piano covers — non-commercial, and underlying "
+        "musical works remain copyrighted.",
+        tags=("piano", "emotion-labels"),
+    ),
+    DatasetEntry(
+        name="Aria-MIDI",
+        source_url="https://github.com/EleutherAI/aria",
+        license="verify at source",
+        description="~1M piano MIDI transcriptions from public performance recordings; large-scale "
+        "symbolic pretraining material.",
+        notes="Transcription does not clear rights on the underlying recordings — verify the release "
+        "license and treat commercial use as unresolved.",
+        tags=("piano", "transcription", "large-scale"),
+    ),
+    DatasetEntry(
+        name="music21 corpus",
+        source_url="https://www.music21.org/music21docs/about/referenceCorpus.html",
+        license="per-work (mostly public domain)",
+        description="Curated corpus bundled with music21: Bach chorales, folk songs, and other largely "
+        "public-domain scores in symbolic form.",
+        notes="music21 itself is BSD-licensed; individual corpus works are mostly public domain but a few "
+        "carry their own restrictions — check per work.",
+        tags=("classical", "public-domain"),
     ),
 ]
 
@@ -58,7 +206,9 @@ def load_manifest(path: Union[str, Path]) -> List[DatasetEntry]:
     """Load a local JSON manifest file (a list of dataset-entry objects).
 
     This never fetches data over the network — it only parses a manifest
-    describing datasets the user has already made available locally.
+    describing datasets the user has already made available locally. Run the
+    result through :func:`creative_audio_lab.data.provenance.validate_manifest`
+    before using it for anything training-related.
     """
     manifest_path = Path(path)
     if not manifest_path.exists():
@@ -67,7 +217,9 @@ def load_manifest(path: Union[str, Path]) -> List[DatasetEntry]:
             "see docs/DATASETS.md for how to source and register one locally."
         )
     raw = json.loads(manifest_path.read_text())
-    return [DatasetEntry(**entry) for entry in raw]
+    if not isinstance(raw, list):
+        raise ValueError(f"Manifest {manifest_path} must contain a JSON list of dataset entries")
+    return [entry_from_dict(entry) for entry in raw]
 
 
-__all__ = ["DatasetEntry", "RECOMMENDED_DATASETS", "load_manifest"]
+__all__ = ["DatasetEntry", "RECOMMENDED_DATASETS", "entry_from_dict", "load_manifest"]

--- a/src/creative_audio_lab/data/license_policy.py
+++ b/src/creative_audio_lab/data/license_policy.py
@@ -1,0 +1,136 @@
+"""License classification and use-policy checks for dataset entries.
+
+A small, explicit table of common data licenses mapped to what they allow.
+This is engineering guardrail code, not legal advice — anything not in the
+table is treated as *unknown* and surfaces as a violation until a human has
+actually verified the terms.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from .dataset_manifest import DatasetEntry
+
+
+@dataclass(frozen=True)
+class LicenseRule:
+    """What a known license allows, for the purposes of dataset intake."""
+
+    commercial_use: bool
+    attribution_required: bool
+
+
+# Canonical license id -> rule. Ids are the normalized form produced by
+# normalize_license (lowercase, hyphenated, version numbers stripped).
+KNOWN_LICENSES: Dict[str, LicenseRule] = {
+    "cc0": LicenseRule(commercial_use=True, attribution_required=False),
+    "public-domain": LicenseRule(commercial_use=True, attribution_required=False),
+    "cc-by": LicenseRule(commercial_use=True, attribution_required=True),
+    "cc-by-sa": LicenseRule(commercial_use=True, attribution_required=True),
+    "cc-by-nc": LicenseRule(commercial_use=False, attribution_required=True),
+    "cc-by-nc-sa": LicenseRule(commercial_use=False, attribution_required=True),
+    "cc-by-nc-nd": LicenseRule(commercial_use=False, attribution_required=True),
+    "mit": LicenseRule(commercial_use=True, attribution_required=True),
+    "bsd": LicenseRule(commercial_use=True, attribution_required=True),
+    "apache": LicenseRule(commercial_use=True, attribution_required=True),
+    "research-only": LicenseRule(commercial_use=False, attribution_required=False),
+}
+
+
+def normalize_license(raw: str) -> str:
+    """Normalize a license string to a canonical lookup id.
+
+    ``"CC BY-NC-SA 4.0"`` → ``"cc-by-nc-sa"``, ``"Apache 2.0"`` → ``"apache"``,
+    ``"  MIT License "`` → ``"mit"``. Unrecognized strings normalize but won't
+    match :data:`KNOWN_LICENSES`.
+    """
+    text = raw.strip().lower()
+    text = re.sub(r"\b\d+(\.\d+)*\b", "", text)  # strip version numbers
+    text = text.replace("license", "").replace("creative commons", "cc")
+    text = re.sub(r"[\s_/]+", "-", text.strip())
+    return text.strip("-")
+
+
+@dataclass(frozen=True)
+class LicenseAssessment:
+    """The outcome of looking a license string up against :data:`KNOWN_LICENSES`."""
+
+    raw: str
+    normalized: str
+    known: bool
+    commercial_use: Optional[bool]
+    attribution_required: Optional[bool]
+
+
+def assess_license(raw: str) -> LicenseAssessment:
+    """Classify a license string; unknown licenses come back with ``None`` allowances."""
+    normalized = normalize_license(raw) if raw else ""
+    rule = KNOWN_LICENSES.get(normalized)
+    return LicenseAssessment(
+        raw=raw,
+        normalized=normalized,
+        known=rule is not None,
+        commercial_use=rule.commercial_use if rule else None,
+        attribution_required=rule.attribution_required if rule else None,
+    )
+
+
+def check_entry_license(entry: DatasetEntry, *, intended_use: str = "research") -> List[str]:
+    """Return human-readable policy violations for using ``entry`` as ``intended_use``.
+
+    Parameters
+    ----------
+    entry:
+        The dataset entry to check.
+    intended_use:
+        Either ``"research"`` or ``"commercial"``.
+
+    Returns
+    -------
+    list of str
+        Empty when no violation was detected. Unknown always errs on the
+        side of a violation for commercial use.
+    """
+    if intended_use not in ("research", "commercial"):
+        raise ValueError(f"intended_use must be 'research' or 'commercial', got {intended_use!r}")
+
+    violations: List[str] = []
+    if not entry.license:
+        violations.append(f"{entry.name}: no license recorded — cannot approve any training use.")
+        return violations
+
+    assessment = assess_license(entry.license)
+    # The manifest's explicit flag wins over the table; the table fills gaps.
+    commercial_ok = entry.commercial_use_allowed
+    if commercial_ok is None:
+        commercial_ok = assessment.commercial_use
+
+    if intended_use == "commercial":
+        if commercial_ok is None:
+            violations.append(
+                f"{entry.name}: commercial use is unverified for license {entry.license!r} — "
+                "verify the terms before any commercial training use."
+            )
+        elif not commercial_ok:
+            violations.append(
+                f"{entry.name}: license {entry.license!r} does not permit commercial use."
+            )
+    elif not assessment.known and entry.commercial_use_allowed is None:
+        violations.append(
+            f"{entry.name}: license {entry.license!r} is not a recognized license id — "
+            "record the actual terms (and commercial_use_allowed) after reviewing the source."
+        )
+    return violations
+
+
+__all__ = [
+    "KNOWN_LICENSES",
+    "LicenseRule",
+    "LicenseAssessment",
+    "normalize_license",
+    "assess_license",
+    "check_entry_license",
+]

--- a/src/creative_audio_lab/data/provenance.py
+++ b/src/creative_audio_lab/data/provenance.py
@@ -1,0 +1,130 @@
+"""Provenance validation for dataset manifest entries.
+
+Every dataset a future training pipeline touches should pass through
+:func:`validate_entry` first, so missing licenses, unverified commercial
+terms, and fan-archive material get flagged *before* they contaminate a
+training corpus — not discovered afterwards.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+
+from .dataset_manifest import DatasetEntry
+
+# Tags that mark a dataset as private reference/evaluation material only —
+# never training data — until its rights are actually cleared.
+UNCLEAR_RIGHTS_TAGS = frozenset(
+    {
+        "fan-archive",
+        "fan-made",
+        "game-rip",
+        "anime-rip",
+        "unclear-rights",
+        "unlicensed",
+    }
+)
+
+SEVERITY_ERROR = "error"
+SEVERITY_WARNING = "warning"
+
+
+@dataclass(frozen=True)
+class ProvenanceIssue:
+    """One problem found while validating a dataset entry's provenance."""
+
+    severity: str  # SEVERITY_ERROR or SEVERITY_WARNING
+    field: str
+    message: str
+
+
+def validate_entry(entry: DatasetEntry) -> List[ProvenanceIssue]:
+    """Check one dataset entry's provenance record.
+
+    Errors (must be fixed before training use):
+
+    - missing license
+    - missing source URL
+    - tagged as fan archive / unclear rights
+
+    Warnings (should be resolved, but don't block reference use):
+
+    - ``commercial_use_allowed`` unknown (``None``)
+    """
+    issues: List[ProvenanceIssue] = []
+
+    if not entry.license.strip():
+        issues.append(
+            ProvenanceIssue(
+                severity=SEVERITY_ERROR,
+                field="license",
+                message=f"{entry.name}: license is missing. Record the license (or 'unknown' plus "
+                "notes on what still needs verifying) before this dataset can be considered.",
+            )
+        )
+    if not entry.source_url.strip():
+        issues.append(
+            ProvenanceIssue(
+                severity=SEVERITY_ERROR,
+                field="source_url",
+                message=f"{entry.name}: source URL is missing. Provenance requires knowing where the "
+                "data actually came from — 'found on a forum' is not a source.",
+            )
+        )
+    if entry.commercial_use_allowed is None:
+        issues.append(
+            ProvenanceIssue(
+                severity=SEVERITY_WARNING,
+                field="commercial_use_allowed",
+                message=f"{entry.name}: commercial_use_allowed is unknown. Verify the license terms and "
+                "set it explicitly before relying on this dataset.",
+            )
+        )
+    flagged = UNCLEAR_RIGHTS_TAGS.intersection(tag.strip().lower() for tag in entry.tags)
+    if flagged:
+        issues.append(
+            ProvenanceIssue(
+                severity=SEVERITY_ERROR,
+                field="tags",
+                message=f"{entry.name}: tagged {sorted(flagged)} — treat as private reference/evaluation "
+                "material only. Fan archives and unclear-rights collections must not be used for "
+                "training unless properly licensed.",
+            )
+        )
+    return issues
+
+
+def validate_manifest(entries: Iterable[DatasetEntry]) -> Dict[str, List[ProvenanceIssue]]:
+    """Validate a whole manifest; returns ``{dataset name: issues}`` for entries with issues."""
+    report: Dict[str, List[ProvenanceIssue]] = {}
+    for entry in entries:
+        issues = validate_entry(entry)
+        if issues:
+            report[entry.name] = issues
+    return report
+
+
+def has_errors(issues: Sequence[ProvenanceIssue]) -> bool:
+    """Return ``True`` if any issue in ``issues`` is an error (vs. a warning)."""
+    return any(issue.severity == SEVERITY_ERROR for issue in issues)
+
+
+def assert_training_ready(entry: DatasetEntry) -> None:
+    """Raise ``ValueError`` (listing every error) if ``entry`` is not fit for training use."""
+    errors = [issue for issue in validate_entry(entry) if issue.severity == SEVERITY_ERROR]
+    if errors:
+        details = "\n".join(f"- {issue.message}" for issue in errors)
+        raise ValueError(f"Dataset {entry.name!r} is not training-ready:\n{details}")
+
+
+__all__ = [
+    "UNCLEAR_RIGHTS_TAGS",
+    "SEVERITY_ERROR",
+    "SEVERITY_WARNING",
+    "ProvenanceIssue",
+    "validate_entry",
+    "validate_manifest",
+    "has_errors",
+    "assert_training_ready",
+]

--- a/src/creative_audio_lab/models/__init__.py
+++ b/src/creative_audio_lab/models/__init__.py
@@ -1,0 +1,61 @@
+"""Generation backends (Stage 1.5 ML readiness).
+
+Defines the :class:`~creative_audio_lab.models.base.GenerationBackend`
+interface, the default :class:`DeterministicBackend` wrapping the existing
+parser + generators, and placeholder adapters marking where learned models
+(Text2midi-style, MIDI-LLM-style) will plug in later. No model is trained,
+bundled, or downloaded by anything in this package.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Type
+
+from .base import BackendInfo, GenerationBackend
+from .deterministic_backend import DeterministicBackend
+from .midi_llm_adapter import MidiLlmAdapter
+from .text2midi_adapter import Text2MidiAdapter
+
+DEFAULT_BACKEND_NAME = DeterministicBackend.name
+
+#: Registry of every known backend, keyed by its stable name.
+BACKEND_REGISTRY: Dict[str, Type[GenerationBackend]] = {
+    DeterministicBackend.name: DeterministicBackend,
+    Text2MidiAdapter.name: Text2MidiAdapter,
+    MidiLlmAdapter.name: MidiLlmAdapter,
+}
+
+
+def get_backend(name: str = DEFAULT_BACKEND_NAME) -> GenerationBackend:
+    """Instantiate the backend registered under ``name``.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not a registered backend, listing the valid names.
+    """
+    try:
+        backend_cls = BACKEND_REGISTRY[name]
+    except KeyError:
+        raise KeyError(
+            f"Unknown backend {name!r}; registered backends: {sorted(BACKEND_REGISTRY)}"
+        ) from None
+    return backend_cls()
+
+
+def list_backends() -> List[BackendInfo]:
+    """Return :class:`BackendInfo` metadata for every registered backend."""
+    return [backend_cls().info() for backend_cls in BACKEND_REGISTRY.values()]
+
+
+__all__ = [
+    "BackendInfo",
+    "GenerationBackend",
+    "DeterministicBackend",
+    "Text2MidiAdapter",
+    "MidiLlmAdapter",
+    "BACKEND_REGISTRY",
+    "DEFAULT_BACKEND_NAME",
+    "get_backend",
+    "list_backends",
+]

--- a/src/creative_audio_lab/models/base.py
+++ b/src/creative_audio_lab/models/base.py
@@ -1,0 +1,86 @@
+"""The common interface every generation backend implements.
+
+A *backend* turns a text prompt (plus optional user overrides) into an
+:class:`~creative_audio_lab.generators.arrangement.Arrangement`. The
+deterministic rule-based pipeline is the first and default implementation;
+future learned models (Text2midi-style text-conditioned generation, or a
+MIDI LLM) plug in behind the same interface so the app, export, and
+evaluation layers never need to know which one produced the notes.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import ClassVar, List, Optional, Tuple
+
+from ..generators.arrangement import Arrangement
+
+
+@dataclass(frozen=True)
+class BackendInfo:
+    """Static metadata describing a backend, for UIs and registries."""
+
+    name: str
+    display_name: str
+    description: str
+    available: bool
+    requires: Tuple[str, ...]
+
+
+class GenerationBackend(ABC):
+    """Abstract base class for prompt-to-arrangement generation backends.
+
+    Subclasses set the class attributes below and implement
+    :meth:`generate`. Backends whose runtime requirements are missing (e.g.
+    a model checkpoint or an optional extra) should report
+    ``is_available == False`` and raise a helpful error from
+    :meth:`generate` instead of failing at import time.
+    """
+
+    #: Stable registry key (e.g. ``"deterministic"``).
+    name: ClassVar[str] = "abstract"
+    #: Human-readable name for UI display.
+    display_name: ClassVar[str] = "Abstract backend"
+    #: One-or-two-sentence description of how the backend generates music.
+    description: ClassVar[str] = ""
+    #: pip extras / external projects the backend needs (informational).
+    requires: ClassVar[Tuple[str, ...]] = ()
+
+    @property
+    def is_available(self) -> bool:
+        """Whether the backend can actually generate right now."""
+        return True
+
+    def info(self) -> BackendInfo:
+        """Return static metadata plus current availability."""
+        return BackendInfo(
+            name=self.name,
+            display_name=self.display_name,
+            description=self.description,
+            available=self.is_available,
+            requires=self.requires,
+        )
+
+    @abstractmethod
+    def generate(
+        self,
+        prompt: str,
+        *,
+        key: Optional[str] = None,
+        mode: Optional[str] = None,
+        bpm: Optional[int] = None,
+        bars: Optional[int] = None,
+        style: Optional[str] = None,
+        energy: Optional[str] = None,
+        density: Optional[str] = None,
+        instruments: Optional[List[str]] = None,
+    ) -> Arrangement:
+        """Generate a full arrangement from ``prompt``.
+
+        Keyword overrides mirror the Streamlit sidebar controls: any that
+        are ``None`` are inferred from the prompt by the backend.
+        """
+
+
+__all__ = ["BackendInfo", "GenerationBackend"]

--- a/src/creative_audio_lab/models/deterministic_backend.py
+++ b/src/creative_audio_lab/models/deterministic_backend.py
@@ -1,0 +1,59 @@
+"""The default backend: the deterministic parser + rule-based generators.
+
+This is a thin wrapper — all real behaviour still lives in
+:mod:`creative_audio_lab.prompt_parser` and
+:mod:`creative_audio_lab.generators`. Wrapping it behind
+:class:`~creative_audio_lab.models.base.GenerationBackend` is what lets a
+future learned backend swap in without touching the app.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ..generators.arrangement import Arrangement, build_arrangement
+from ..prompt_parser import parse_prompt
+from .base import GenerationBackend
+
+
+class DeterministicBackend(GenerationBackend):
+    """Rule-based prompt-to-MIDI generation (the current default)."""
+
+    name = "deterministic"
+    display_name = "Deterministic baseline"
+    description = (
+        "Keyword-based prompt parsing plus rule-based chord/melody/bass/drum "
+        "generators. Fully explainable, reproducible per prompt, and requires "
+        "no trained model."
+    )
+    requires = ()
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        key: Optional[str] = None,
+        mode: Optional[str] = None,
+        bpm: Optional[int] = None,
+        bars: Optional[int] = None,
+        style: Optional[str] = None,
+        energy: Optional[str] = None,
+        density: Optional[str] = None,
+        instruments: Optional[List[str]] = None,
+    ) -> Arrangement:
+        """Parse ``prompt`` into controls (honouring overrides) and build the arrangement."""
+        controls = parse_prompt(
+            prompt,
+            key=key,
+            mode=mode,
+            bpm=bpm,
+            bars=bars,
+            style=style,
+            energy=energy,
+            density=density,
+            instruments=instruments,
+        )
+        return build_arrangement(controls)
+
+
+__all__ = ["DeterministicBackend"]

--- a/src/creative_audio_lab/models/midi_llm_adapter.py
+++ b/src/creative_audio_lab/models/midi_llm_adapter.py
@@ -1,0 +1,73 @@
+"""Placeholder adapter for a MIDI-LLM style backend (LLM over MIDI tokens).
+
+The "MIDI-LLM" family of approaches adapts a pretrained text LLM to emit
+symbolic music tokens (an expanded vocabulary over a base model, or plain
+text formats like ABC/MIDI-text). It is a *candidate future integration*,
+not a dependency — nothing here imports any external model repo, and no
+checkpoint ships with this project.
+
+Like :class:`~creative_audio_lab.models.text2midi_adapter.Text2MidiAdapter`,
+this adapter exists to pin down the integration surface early: implement
+:meth:`MidiLlmAdapter.generate` and the rest of the app works unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ..generators.arrangement import Arrangement
+from .base import GenerationBackend
+
+_NOT_IMPLEMENTED_GUIDANCE = (
+    "MidiLlmAdapter is a scaffolding placeholder — no MIDI-capable LLM is "
+    "integrated or shipped yet.\n\n"
+    "To integrate one later:\n"
+    "  1. Install the ML extras: pip install \"creative-audio-lab[ml]\" (torch, "
+    "transformers) and pick a MIDI-token LLM (e.g. a model with a vocabulary "
+    "expanded for symbolic music tokens).\n"
+    "  2. Map the prompt (and any GenerationControls overrides) into the model's "
+    "conditioning format.\n"
+    "  3. Sample a token sequence and decode it into Note events via "
+    "creative_audio_lab.tokenization (SymbolicTokenizer for the internal REMI-style "
+    "vocabulary, MidiTokRemiAdapter for MidiTok formats).\n"
+    "  4. Assemble the notes into an Arrangement (parts + General MIDI programs) "
+    "so export and evaluation work unchanged.\n\n"
+    "Until then, use the default deterministic backend: "
+    "creative_audio_lab.models.get_backend(\"deterministic\")."
+)
+
+
+class MidiLlmAdapter(GenerationBackend):
+    """Future adapter for LLM-based symbolic generation (not yet implemented)."""
+
+    name = "midi_llm"
+    display_name = "MIDI-LLM (future adapter)"
+    description = (
+        "Planned adapter for a text LLM adapted to emit symbolic music tokens. "
+        "Scaffolded only — no model is trained, bundled, or downloaded."
+    )
+    requires = ("ml extra (torch, transformers)", "MIDI-token LLM weights (external)")
+
+    @property
+    def is_available(self) -> bool:
+        """Always ``False``: this adapter is scaffolding, not an integration."""
+        return False
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        key: Optional[str] = None,
+        mode: Optional[str] = None,
+        bpm: Optional[int] = None,
+        bars: Optional[int] = None,
+        style: Optional[str] = None,
+        energy: Optional[str] = None,
+        density: Optional[str] = None,
+        instruments: Optional[List[str]] = None,
+    ) -> Arrangement:
+        """Not implemented — raises with step-by-step integration guidance."""
+        raise NotImplementedError(_NOT_IMPLEMENTED_GUIDANCE)
+
+
+__all__ = ["MidiLlmAdapter"]

--- a/src/creative_audio_lab/models/text2midi_adapter.py
+++ b/src/creative_audio_lab/models/text2midi_adapter.py
@@ -1,0 +1,73 @@
+"""Placeholder adapter for a Text2midi-style text-conditioned symbolic model.
+
+`Text2midi <https://github.com/AMAAI-Lab/Text2midi>`_ (AMAAI Lab) generates
+MIDI token sequences from free-text captions with an LLM-encoder +
+transformer-decoder architecture, trained on caption-paired MIDI such as
+MidiCaps. It is a *candidate future integration*, not a dependency — nothing
+here imports it, and no checkpoint ships with this project.
+
+The adapter exists so the integration surface is designed now: the app
+already selects backends through
+:class:`~creative_audio_lab.models.base.GenerationBackend`, so a working
+implementation of :meth:`Text2MidiAdapter.generate` is all that's missing.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ..generators.arrangement import Arrangement
+from .base import GenerationBackend
+
+_NOT_IMPLEMENTED_GUIDANCE = (
+    "Text2MidiAdapter is a scaffolding placeholder — no Text2midi model is "
+    "integrated or shipped yet.\n\n"
+    "To integrate one later:\n"
+    "  1. Install the ML extras: pip install \"creative-audio-lab[ml]\" (torch, "
+    "transformers) and obtain the Text2midi weights per the upstream repo's license.\n"
+    "  2. Encode the prompt and sample a symbolic token sequence from the model.\n"
+    "  3. Decode tokens into Note events — creative_audio_lab.tokenization."
+    "SymbolicTokenizer.decode already handles the REMI-style vocabulary, and "
+    "MidiTokRemiAdapter covers MidiTok-formatted output.\n"
+    "  4. Assemble the notes into an Arrangement (parts + General MIDI programs) "
+    "so export and evaluation work unchanged.\n\n"
+    "Until then, use the default deterministic backend: "
+    "creative_audio_lab.models.get_backend(\"deterministic\")."
+)
+
+
+class Text2MidiAdapter(GenerationBackend):
+    """Future adapter for caption-conditioned symbolic generation (not yet implemented)."""
+
+    name = "text2midi"
+    display_name = "Text2midi (future adapter)"
+    description = (
+        "Planned adapter for a Text2midi-style caption-conditioned transformer "
+        "that generates MIDI token sequences from free text. Scaffolded only — "
+        "no model is trained, bundled, or downloaded."
+    )
+    requires = ("ml extra (torch, transformers)", "Text2midi weights (external)")
+
+    @property
+    def is_available(self) -> bool:
+        """Always ``False``: this adapter is scaffolding, not an integration."""
+        return False
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        key: Optional[str] = None,
+        mode: Optional[str] = None,
+        bpm: Optional[int] = None,
+        bars: Optional[int] = None,
+        style: Optional[str] = None,
+        energy: Optional[str] = None,
+        density: Optional[str] = None,
+        instruments: Optional[List[str]] = None,
+    ) -> Arrangement:
+        """Not implemented — raises with step-by-step integration guidance."""
+        raise NotImplementedError(_NOT_IMPLEMENTED_GUIDANCE)
+
+
+__all__ = ["Text2MidiAdapter"]

--- a/src/creative_audio_lab/preview/__init__.py
+++ b/src/creative_audio_lab/preview/__init__.py
@@ -1,0 +1,20 @@
+"""Lightweight MIDI preview/analysis layer (no audio rendering).
+
+Summaries (:mod:`.midi_summary`) and piano-roll grids (:mod:`.piano_roll`)
+are pure data structures computed from :class:`Note` events — no DAW,
+plugin host, or audio dependency involved. They give the app (and future
+dataset tooling) something inspectable to show before a user drags the
+MIDI into a DAW.
+"""
+
+from .midi_summary import MidiSummary, TrackSummary, summarize_arrangement, summarize_tracks
+from .piano_roll import PianoRoll, build_piano_roll
+
+__all__ = [
+    "MidiSummary",
+    "TrackSummary",
+    "summarize_arrangement",
+    "summarize_tracks",
+    "PianoRoll",
+    "build_piano_roll",
+]

--- a/src/creative_audio_lab/preview/midi_summary.py
+++ b/src/creative_audio_lab/preview/midi_summary.py
@@ -1,0 +1,147 @@
+"""Per-track and whole-piece summaries of symbolic note content.
+
+Pure functions over :class:`Note` lists — usable on generated arrangements
+and on parsed MIDI files alike (pair with
+:func:`creative_audio_lab.midi_parser.parse_midi_file` for the latter).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from ..music_theory import Note
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard for type hints only
+    from ..generators.arrangement import Arrangement
+
+
+@dataclass(frozen=True)
+class TrackSummary:
+    """Summary statistics for one track/part."""
+
+    name: str
+    program: Optional[int]
+    is_drum: bool
+    note_count: int
+    pitch_min: Optional[int]
+    pitch_max: Optional[int]
+    duration_beats: float
+    duration_bars: float
+    notes_per_bar: float
+
+
+@dataclass(frozen=True)
+class MidiSummary:
+    """Summary of a whole piece: per-track stats plus piece-level totals."""
+
+    tracks: Tuple[TrackSummary, ...]
+    total_notes: int
+    duration_beats: float
+    duration_bars: float
+    has_drums: bool
+    bpm: Optional[float] = None
+
+    @property
+    def pitch_range(self) -> Optional[Tuple[int, int]]:
+        """Lowest/highest pitch across all non-drum tracks, or ``None`` if there are no pitched notes."""
+        lows = [t.pitch_min for t in self.tracks if not t.is_drum and t.pitch_min is not None]
+        highs = [t.pitch_max for t in self.tracks if not t.is_drum and t.pitch_max is not None]
+        if not lows or not highs:
+            return None
+        return (min(lows), max(highs))
+
+
+def summarize_notes(
+    name: str,
+    notes: Sequence[Note],
+    *,
+    program: Optional[int] = None,
+    is_drum: bool = False,
+    beats_per_bar: float = 4.0,
+) -> TrackSummary:
+    """Summarize one note list as a :class:`TrackSummary`.
+
+    ``duration_bars`` is rounded up to whole bars; ``notes_per_bar`` is the
+    density over that span (0.0 for an empty track).
+    """
+    if not notes:
+        return TrackSummary(
+            name=name,
+            program=program,
+            is_drum=is_drum,
+            note_count=0,
+            pitch_min=None,
+            pitch_max=None,
+            duration_beats=0.0,
+            duration_bars=0.0,
+            notes_per_bar=0.0,
+        )
+    duration_beats = max(note.end() for note in notes)
+    duration_bars = math.ceil(duration_beats / beats_per_bar) if duration_beats > 0 else 0
+    pitches = [note.pitch for note in notes]
+    return TrackSummary(
+        name=name,
+        program=program,
+        is_drum=is_drum,
+        note_count=len(notes),
+        pitch_min=min(pitches),
+        pitch_max=max(pitches),
+        duration_beats=duration_beats,
+        duration_bars=float(duration_bars),
+        notes_per_bar=len(notes) / duration_bars if duration_bars else 0.0,
+    )
+
+
+def summarize_tracks(
+    tracks: Mapping[str, Sequence[Note]],
+    *,
+    programs: Optional[Mapping[str, int]] = None,
+    drum_tracks: Sequence[str] = ("drums",),
+    bpm: Optional[float] = None,
+    beats_per_bar: float = 4.0,
+) -> MidiSummary:
+    """Summarize a ``{track_name: notes}`` mapping into a :class:`MidiSummary`.
+
+    ``drum_tracks`` names which tracks are percussion (no meaningful pitch
+    range); ``programs`` optionally maps track names to General MIDI program
+    numbers.
+    """
+    programs = programs or {}
+    drum_names = set(drum_tracks)
+    summaries: List[TrackSummary] = [
+        summarize_notes(
+            name,
+            notes,
+            program=programs.get(name),
+            is_drum=name in drum_names,
+            beats_per_bar=beats_per_bar,
+        )
+        for name, notes in tracks.items()
+    ]
+    duration_beats = max((t.duration_beats for t in summaries), default=0.0)
+    duration_bars = max((t.duration_bars for t in summaries), default=0.0)
+    return MidiSummary(
+        tracks=tuple(summaries),
+        total_notes=sum(t.note_count for t in summaries),
+        duration_beats=duration_beats,
+        duration_bars=duration_bars,
+        has_drums=any(t.is_drum and t.note_count > 0 for t in summaries),
+        bpm=bpm,
+    )
+
+
+def summarize_arrangement(arrangement: "Arrangement", *, beats_per_bar: float = 4.0) -> MidiSummary:
+    """Summarize a generated :class:`Arrangement` (parts, programs, BPM included)."""
+    parts: Dict[str, Sequence[Note]] = dict(arrangement.parts)
+    return summarize_tracks(
+        parts,
+        programs=arrangement.programs,
+        drum_tracks=("drums",),
+        bpm=arrangement.bpm,
+        beats_per_bar=beats_per_bar,
+    )
+
+
+__all__ = ["TrackSummary", "MidiSummary", "summarize_notes", "summarize_tracks", "summarize_arrangement"]

--- a/src/creative_audio_lab/preview/piano_roll.py
+++ b/src/creative_audio_lab/preview/piano_roll.py
@@ -1,0 +1,96 @@
+"""Piano-roll grid data structure (data only — no image rendering).
+
+A :class:`PianoRoll` is a time-major velocity grid: ``grid[step][row]`` is
+the loudest velocity sounding at that time step for the pitch
+``pitch_low + row`` (0 = silent). Plain nested tuples keep it trivially
+testable and serializable; a UI layer can render it however it likes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+from ..music_theory import Note
+
+
+@dataclass(frozen=True)
+class PianoRoll:
+    """A quantized pitch/time velocity grid built from note events."""
+
+    pitch_low: int
+    pitch_high: int
+    steps_per_beat: int
+    grid: Tuple[Tuple[int, ...], ...]  # grid[step][pitch_row] = velocity (0 = silent)
+
+    @property
+    def num_steps(self) -> int:
+        """Number of time steps (grid rows)."""
+        return len(self.grid)
+
+    @property
+    def num_pitches(self) -> int:
+        """Number of pitch rows spanned (``pitch_high - pitch_low + 1``; 0 when empty)."""
+        return (self.pitch_high - self.pitch_low + 1) if self.grid else 0
+
+    @property
+    def duration_beats(self) -> float:
+        """Total time span covered, in beats."""
+        return self.num_steps / self.steps_per_beat
+
+    def active_pitches(self, step: int) -> List[int]:
+        """Return the MIDI pitches sounding at ``step`` (ascending)."""
+        return [
+            self.pitch_low + row
+            for row, velocity in enumerate(self.grid[step])
+            if velocity > 0
+        ]
+
+
+def build_piano_roll(
+    notes: Sequence[Note],
+    *,
+    steps_per_beat: int = 4,
+    pitch_low: Optional[int] = None,
+    pitch_high: Optional[int] = None,
+) -> PianoRoll:
+    """Quantize ``notes`` onto a piano-roll grid.
+
+    Each note occupies every step from its onset up to (but excluding) its
+    end, with a minimum of one step; overlapping notes on the same pitch
+    keep the loudest velocity. ``pitch_low``/``pitch_high`` default to the
+    notes' own pitch extremes. An empty note list yields an empty grid.
+    """
+    if steps_per_beat < 1:
+        raise ValueError("steps_per_beat must be >= 1")
+    if not notes:
+        return PianoRoll(pitch_low=0, pitch_high=0, steps_per_beat=steps_per_beat, grid=())
+
+    low = pitch_low if pitch_low is not None else min(note.pitch for note in notes)
+    high = pitch_high if pitch_high is not None else max(note.pitch for note in notes)
+    if low > high:
+        raise ValueError(f"pitch_low ({low}) must be <= pitch_high ({high})")
+
+    num_steps = max(round(note.end() * steps_per_beat) for note in notes)
+    num_steps = max(num_steps, 1)
+    num_pitches = high - low + 1
+    cells: List[List[int]] = [[0] * num_pitches for _ in range(num_steps)]
+
+    for note in notes:
+        if not low <= note.pitch <= high:
+            continue
+        start_step = round(note.start * steps_per_beat)
+        end_step = max(round(note.end() * steps_per_beat), start_step + 1)
+        row = note.pitch - low
+        for step in range(start_step, min(end_step, num_steps)):
+            cells[step][row] = max(cells[step][row], note.velocity)
+
+    return PianoRoll(
+        pitch_low=low,
+        pitch_high=high,
+        steps_per_beat=steps_per_beat,
+        grid=tuple(tuple(step_cells) for step_cells in cells),
+    )
+
+
+__all__ = ["PianoRoll", "build_piano_roll"]

--- a/src/creative_audio_lab/tokenization/__init__.py
+++ b/src/creative_audio_lab/tokenization/__init__.py
@@ -1,0 +1,29 @@
+"""Symbolic tokenization layer (Stage 1.5 ML readiness).
+
+Converts the package's canonical :class:`~creative_audio_lab.music_theory.Note`
+events into flat symbolic token sequences (and back), the representation a
+future text-conditioned symbolic model would train on.
+
+Two paths are provided:
+
+- :class:`SymbolicTokenizer` — a dependency-free, REMI-style internal
+  tokenizer that works with only the core install.
+- :class:`~creative_audio_lab.tokenization.miditok_adapter.MidiTokRemiAdapter`
+  — an optional wrapper around `MidiTok <https://github.com/Natooz/MidiTok>`_
+  (requires ``pip install "creative-audio-lab[symbolic]"``) for tokenizing
+  MIDI files with the battle-tested REMI implementation.
+"""
+
+from .symbolic_tokenizer import DecodedSequence, SymbolicTokenizer, TokenizerConfig
+from .token_types import Token, TokenType, strings_to_tokens, token_from_string, tokens_to_strings
+
+__all__ = [
+    "DecodedSequence",
+    "SymbolicTokenizer",
+    "TokenizerConfig",
+    "Token",
+    "TokenType",
+    "token_from_string",
+    "tokens_to_strings",
+    "strings_to_tokens",
+]

--- a/src/creative_audio_lab/tokenization/miditok_adapter.py
+++ b/src/creative_audio_lab/tokenization/miditok_adapter.py
@@ -1,0 +1,101 @@
+"""Optional MidiTok/symusic adapter for tokenizing MIDI files with REMI.
+
+MidiTok and symusic are **not** core dependencies. Install them with::
+
+    pip install "creative-audio-lab[symbolic]"
+
+Everything in this module degrades gracefully when they are absent:
+:func:`is_miditok_available` reports availability, and constructing
+:class:`MidiTokRemiAdapter` without them raises
+:class:`MidiTokNotAvailableError` with installation guidance instead of a
+bare ``ImportError`` deep inside a third-party import.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+_INSTALL_HINT = (
+    "MidiTok-based tokenization requires the optional 'miditok' and 'symusic' "
+    "packages, which are not installed. Install them with:\n\n"
+    '    pip install "creative-audio-lab[symbolic]"\n\n'
+    "The core prompt-to-MIDI app does not need them — the dependency-free "
+    "creative_audio_lab.tokenization.SymbolicTokenizer covers note-event "
+    "tokenization without any extras."
+)
+
+
+class MidiTokNotAvailableError(ImportError):
+    """Raised when MidiTok/symusic functionality is requested but not installed."""
+
+
+def is_miditok_available() -> bool:
+    """Return ``True`` if both ``miditok`` and ``symusic`` are importable."""
+    return (
+        importlib.util.find_spec("miditok") is not None
+        and importlib.util.find_spec("symusic") is not None
+    )
+
+
+def require_miditok() -> None:
+    """Raise :class:`MidiTokNotAvailableError` with install guidance if MidiTok is missing."""
+    if not is_miditok_available():
+        raise MidiTokNotAvailableError(_INSTALL_HINT)
+
+
+class MidiTokRemiAdapter:
+    """Thin wrapper around MidiTok's REMI tokenizer for whole MIDI files.
+
+    This exists so future dataset preprocessing can use the reference REMI
+    implementation (via MidiTok + symusic) while the rest of the codebase
+    keeps depending only on the internal
+    :class:`~creative_audio_lab.tokenization.SymbolicTokenizer`.
+    """
+
+    def __init__(self, tokenizer_params: Optional[Dict[str, Any]] = None) -> None:
+        """Create a REMI tokenizer.
+
+        Parameters
+        ----------
+        tokenizer_params:
+            Optional keyword arguments forwarded to
+            ``miditok.TokenizerConfig`` (beat resolution, velocity bins, ...).
+
+        Raises
+        ------
+        MidiTokNotAvailableError
+            If ``miditok``/``symusic`` are not installed.
+        """
+        require_miditok()
+        import miditok
+
+        config = miditok.TokenizerConfig(**(tokenizer_params or {}))
+        self._tokenizer = miditok.REMI(config)
+
+    @property
+    def vocab_size(self) -> int:
+        """Size of the underlying REMI vocabulary."""
+        return len(self._tokenizer)
+
+    def tokenize_file(self, path: Union[str, Path]) -> List[str]:
+        """Tokenize a MIDI file on disk into a flat list of REMI token strings.
+
+        Multi-track files are flattened track by track, in file order.
+        """
+        sequences = self._tokenizer(Path(path))
+        if not isinstance(sequences, list):
+            sequences = [sequences]
+        tokens: List[str] = []
+        for sequence in sequences:
+            tokens.extend(sequence.tokens)
+        return tokens
+
+
+__all__ = [
+    "MidiTokNotAvailableError",
+    "MidiTokRemiAdapter",
+    "is_miditok_available",
+    "require_miditok",
+]

--- a/src/creative_audio_lab/tokenization/symbolic_tokenizer.py
+++ b/src/creative_audio_lab/tokenization/symbolic_tokenizer.py
@@ -1,0 +1,208 @@
+"""Dependency-free REMI-style tokenizer over canonical :class:`Note` events.
+
+The encoding follows the REMI convention (bar/position anchoring rather than
+time-shift deltas): an optional metadata header (``TEMPO``,
+``TIME_SIGNATURE``, ``PROGRAM``) followed, per note, by
+
+    ``BAR_<index>`` (when the bar changes) → ``POSITION_<step>`` →
+    ``NOTE_ON_<pitch>`` → ``VELOCITY_<bin>`` → ``DURATION_<steps>``
+
+Timing is quantized to ``positions_per_beat`` steps per beat (default 4, a
+16th-note grid) and velocity to ``velocity_bins`` bins (default 32, i.e.
+bin width 4). Notes that already sit on the grid — which everything the
+deterministic generators emit does — round-trip exactly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+from ..music_theory import Note
+from .token_types import Token, TokenType, strings_to_tokens, tokens_to_strings
+
+DEFAULT_VELOCITY = 96
+
+
+@dataclass(frozen=True)
+class TokenizerConfig:
+    """Quantization settings for :class:`SymbolicTokenizer`.
+
+    Attributes
+    ----------
+    beats_per_bar:
+        Bar length in beats (4.0 = the 4/4 the generators assume).
+    positions_per_beat:
+        Grid resolution: steps per beat for POSITION and DURATION tokens.
+    velocity_bins:
+        Number of velocity bins over the 0-127 MIDI range. 128 is lossless;
+        the default 32 (bin width 4) round-trips velocities that are
+        multiples of 4.
+    max_duration_beats:
+        Durations longer than this are truncated so the DURATION vocabulary
+        stays bounded.
+    """
+
+    beats_per_bar: float = 4.0
+    positions_per_beat: int = 4
+    velocity_bins: int = 32
+    max_duration_beats: float = 8.0
+
+    @property
+    def steps_per_bar(self) -> int:
+        return round(self.beats_per_bar * self.positions_per_beat)
+
+    @property
+    def velocity_bin_width(self) -> int:
+        return max(128 // self.velocity_bins, 1)
+
+
+@dataclass(frozen=True)
+class DecodedSequence:
+    """The result of decoding a token sequence back into note events."""
+
+    notes: Tuple[Note, ...]
+    tempo: Optional[int] = None
+    program: Optional[int] = None
+    time_signature: Optional[str] = None
+
+
+class SymbolicTokenizer:
+    """Encode :class:`Note` events to symbolic tokens and decode them back.
+
+    Works with the core install only — no MidiTok, symusic, or torch
+    required. For tokenizing arbitrary MIDI *files* with the reference REMI
+    implementation, see
+    :class:`~creative_audio_lab.tokenization.miditok_adapter.MidiTokRemiAdapter`.
+    """
+
+    def __init__(self, config: Optional[TokenizerConfig] = None) -> None:
+        self.config = config or TokenizerConfig()
+
+    # ------------------------------------------------------------------
+    # Encoding
+    # ------------------------------------------------------------------
+
+    def encode(
+        self,
+        notes: Sequence[Note],
+        *,
+        tempo: Optional[float] = None,
+        program: Optional[int] = None,
+        time_signature: Optional[str] = None,
+    ) -> List[Token]:
+        """Encode note events (plus optional metadata) into a flat token list.
+
+        Notes are sorted by ``(start, pitch)`` and quantized to the config's
+        position grid; simultaneous notes (chords) share one BAR/POSITION
+        anchor.
+        """
+        cfg = self.config
+        tokens: List[Token] = []
+        if tempo is not None:
+            tokens.append(Token(TokenType.TEMPO, round(tempo)))
+        if time_signature is not None:
+            tokens.append(Token(TokenType.TIME_SIGNATURE, time_signature))
+        if program is not None:
+            tokens.append(Token(TokenType.PROGRAM, int(program)))
+
+        max_duration_steps = max(round(cfg.max_duration_beats * cfg.positions_per_beat), 1)
+        current_bar: Optional[int] = None
+        current_position: Optional[int] = None
+
+        for note in sorted(notes, key=lambda n: (n.start, n.pitch)):
+            total_steps = round(note.start * cfg.positions_per_beat)
+            bar, position = divmod(total_steps, cfg.steps_per_bar)
+            if bar != current_bar:
+                tokens.append(Token(TokenType.BAR, bar))
+                current_bar = bar
+                current_position = None
+            if position != current_position:
+                tokens.append(Token(TokenType.POSITION, position))
+                current_position = position
+
+            duration_steps = min(max(round(note.duration * cfg.positions_per_beat), 1), max_duration_steps)
+            velocity_bin = min(max(note.velocity, 0), 127) // cfg.velocity_bin_width
+            tokens.append(Token(TokenType.NOTE_ON, note.pitch))
+            tokens.append(Token(TokenType.VELOCITY, velocity_bin))
+            tokens.append(Token(TokenType.DURATION, duration_steps))
+
+        return tokens
+
+    def encode_to_strings(
+        self,
+        notes: Sequence[Note],
+        *,
+        tempo: Optional[float] = None,
+        program: Optional[int] = None,
+        time_signature: Optional[str] = None,
+    ) -> List[str]:
+        """Like :meth:`encode`, but returns canonical ``TYPE_value`` strings."""
+        return tokens_to_strings(self.encode(notes, tempo=tempo, program=program, time_signature=time_signature))
+
+    # ------------------------------------------------------------------
+    # Decoding
+    # ------------------------------------------------------------------
+
+    def decode(self, tokens: Sequence[Token]) -> DecodedSequence:
+        """Decode a token sequence back into note events where possible.
+
+        A note is emitted for each ``NOTE_ON`` once its ``DURATION`` token
+        arrives; a missing ``VELOCITY`` falls back to
+        :data:`DEFAULT_VELOCITY`, and a ``NOTE_ON`` never followed by a
+        ``DURATION`` is dropped rather than raising.
+        """
+        cfg = self.config
+        notes: List[Note] = []
+        tempo: Optional[int] = None
+        program: Optional[int] = None
+        time_signature: Optional[str] = None
+
+        current_bar = 0
+        current_position = 0
+        pending_pitch: Optional[int] = None
+        pending_velocity: Optional[int] = None
+
+        for token in tokens:
+            if token.type is TokenType.TEMPO:
+                tempo = int(token.value)
+            elif token.type is TokenType.TIME_SIGNATURE:
+                time_signature = str(token.value)
+            elif token.type is TokenType.PROGRAM:
+                program = int(token.value)
+            elif token.type is TokenType.BAR:
+                current_bar = int(token.value)
+                current_position = 0
+            elif token.type is TokenType.POSITION:
+                current_position = int(token.value)
+            elif token.type is TokenType.NOTE_ON:
+                pending_pitch = int(token.value)
+                pending_velocity = None
+            elif token.type is TokenType.VELOCITY:
+                pending_velocity = int(token.value) * cfg.velocity_bin_width
+            elif token.type is TokenType.DURATION and pending_pitch is not None:
+                start_steps = current_bar * cfg.steps_per_bar + current_position
+                notes.append(
+                    Note(
+                        start=start_steps / cfg.positions_per_beat,
+                        pitch=pending_pitch,
+                        duration=int(token.value) / cfg.positions_per_beat,
+                        velocity=pending_velocity if pending_velocity is not None else DEFAULT_VELOCITY,
+                    )
+                )
+                pending_pitch = None
+                pending_velocity = None
+
+        return DecodedSequence(
+            notes=tuple(notes),
+            tempo=tempo,
+            program=program,
+            time_signature=time_signature,
+        )
+
+    def decode_from_strings(self, strings: Sequence[str]) -> DecodedSequence:
+        """Like :meth:`decode`, but accepts canonical ``TYPE_value`` strings."""
+        return self.decode(strings_to_tokens(strings))
+
+
+__all__ = ["TokenizerConfig", "DecodedSequence", "SymbolicTokenizer", "DEFAULT_VELOCITY"]

--- a/src/creative_audio_lab/tokenization/token_types.py
+++ b/src/creative_audio_lab/tokenization/token_types.py
@@ -1,0 +1,84 @@
+"""Token vocabulary for the internal symbolic tokenizer.
+
+A token is a ``(type, value)`` pair with a canonical string form of
+``TYPE_value`` (e.g. ``NOTE_ON_60``, ``POSITION_8``, ``TIME_SIGNATURE_4/4``),
+mirroring the convention used by MidiTok's REMI tokenizer so sequences stay
+readable and easy to port to an external tokenizer later.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Sequence, Union
+
+
+class TokenType(str, Enum):
+    """The token kinds emitted by :class:`~creative_audio_lab.tokenization.SymbolicTokenizer`."""
+
+    BAR = "BAR"
+    POSITION = "POSITION"
+    PROGRAM = "PROGRAM"
+    NOTE_ON = "NOTE_ON"
+    DURATION = "DURATION"
+    VELOCITY = "VELOCITY"
+    TEMPO = "TEMPO"
+    TIME_SIGNATURE = "TIME_SIGNATURE"
+
+
+@dataclass(frozen=True)
+class Token:
+    """One symbolic token: a :class:`TokenType` plus its value.
+
+    Values are ``int`` for every type except :attr:`TokenType.TIME_SIGNATURE`,
+    which uses a string like ``"4/4"``.
+    """
+
+    type: TokenType
+    value: Union[int, str]
+
+    def to_string(self) -> str:
+        """Render the canonical ``TYPE_value`` string form (e.g. ``"NOTE_ON_60"``)."""
+        return f"{self.type.value}_{self.value}"
+
+
+def token_from_string(text: str) -> Token:
+    """Parse a ``TYPE_value`` string produced by :meth:`Token.to_string` back into a :class:`Token`.
+
+    Raises
+    ------
+    ValueError
+        If ``text`` does not match any known token type.
+    """
+    head, sep, raw_value = text.rpartition("_")
+    if not sep:
+        raise ValueError(f"Not a valid token string: {text!r}")
+    try:
+        token_type = TokenType(head)
+    except ValueError:
+        raise ValueError(f"Unknown token type in {text!r}") from None
+    value: Union[int, str]
+    try:
+        value = int(raw_value)
+    except ValueError:
+        value = raw_value
+    return Token(type=token_type, value=value)
+
+
+def tokens_to_strings(tokens: Sequence[Token]) -> List[str]:
+    """Convert a token sequence to its canonical string forms."""
+    return [token.to_string() for token in tokens]
+
+
+def strings_to_tokens(strings: Sequence[str]) -> List[Token]:
+    """Parse a sequence of ``TYPE_value`` strings back into :class:`Token` objects."""
+    return [token_from_string(text) for text in strings]
+
+
+__all__ = [
+    "TokenType",
+    "Token",
+    "token_from_string",
+    "tokens_to_strings",
+    "strings_to_tokens",
+]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,102 @@
+import inspect
+
+import pytest
+
+from creative_audio_lab.generators.arrangement import Arrangement, build_arrangement
+from creative_audio_lab.models import (
+    BACKEND_REGISTRY,
+    DEFAULT_BACKEND_NAME,
+    BackendInfo,
+    DeterministicBackend,
+    GenerationBackend,
+    MidiLlmAdapter,
+    Text2MidiAdapter,
+    get_backend,
+    list_backends,
+)
+from creative_audio_lab.prompt_parser import parse_prompt
+
+PROMPT = "dark orchestral boss battle theme, 140 BPM, brass ostinato, strings, piano arps"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_contains_all_three_backends():
+    assert set(BACKEND_REGISTRY) == {"deterministic", "text2midi", "midi_llm"}
+
+
+def test_default_backend_is_deterministic():
+    assert DEFAULT_BACKEND_NAME == "deterministic"
+    assert isinstance(get_backend(), DeterministicBackend)
+
+
+def test_get_backend_unknown_name_lists_valid_names():
+    with pytest.raises(KeyError, match="deterministic"):
+        get_backend("suno_clone")
+
+
+def test_list_backends_reports_availability():
+    infos = {info.name: info for info in list_backends()}
+    assert all(isinstance(info, BackendInfo) for info in infos.values())
+    assert infos["deterministic"].available is True
+    assert infos["text2midi"].available is False
+    assert infos["midi_llm"].available is False
+
+
+# ---------------------------------------------------------------------------
+# Interface shape
+# ---------------------------------------------------------------------------
+
+
+def test_every_backend_implements_the_generate_interface():
+    expected_params = {"prompt", "key", "mode", "bpm", "bars", "style", "energy", "density", "instruments"}
+    for backend_cls in BACKEND_REGISTRY.values():
+        assert issubclass(backend_cls, GenerationBackend)
+        assert backend_cls.name and backend_cls.display_name and backend_cls.description
+        params = set(inspect.signature(backend_cls.generate).parameters) - {"self"}
+        assert params == expected_params
+
+
+def test_backend_cannot_be_instantiated_without_generate():
+    with pytest.raises(TypeError):
+        GenerationBackend()  # abstract
+
+
+# ---------------------------------------------------------------------------
+# Deterministic backend
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_backend_matches_direct_pipeline():
+    arrangement = DeterministicBackend().generate(PROMPT)
+    direct = build_arrangement(parse_prompt(PROMPT))
+    assert isinstance(arrangement, Arrangement)
+    assert arrangement.parts == direct.parts
+    assert arrangement.programs == direct.programs
+    assert arrangement.bpm == direct.bpm
+
+
+def test_deterministic_backend_honours_overrides():
+    arrangement = DeterministicBackend().generate(PROMPT, bpm=97, bars=4, key="D")
+    assert arrangement.bpm == 97
+    assert arrangement.bars == 4
+    assert arrangement.controls.key == "D"
+
+
+# ---------------------------------------------------------------------------
+# Placeholder adapters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("adapter_cls", [Text2MidiAdapter, MidiLlmAdapter])
+def test_placeholder_adapters_raise_with_guidance(adapter_cls):
+    adapter = adapter_cls()
+    assert adapter.is_available is False
+    with pytest.raises(NotImplementedError) as excinfo:
+        adapter.generate(PROMPT)
+    message = str(excinfo.value)
+    assert "deterministic" in message  # points back at the working default
+    assert "creative-audio-lab[ml]" in message  # names the extras needed later

--- a/tests/test_dataset_provenance.py
+++ b/tests/test_dataset_provenance.py
@@ -1,0 +1,171 @@
+from pathlib import Path
+
+import pytest
+
+from creative_audio_lab.data.dataset_manifest import (
+    RECOMMENDED_DATASETS,
+    DatasetEntry,
+    entry_from_dict,
+    load_manifest,
+)
+from creative_audio_lab.data.license_policy import (
+    assess_license,
+    check_entry_license,
+    normalize_license,
+)
+from creative_audio_lab.data.provenance import (
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+    assert_training_ready,
+    has_errors,
+    validate_entry,
+    validate_manifest,
+)
+
+EXAMPLE_MANIFEST = Path(__file__).resolve().parent.parent / "examples" / "dataset_manifest.example.json"
+
+
+def _clean_entry(**overrides) -> DatasetEntry:
+    fields = dict(
+        name="clean-set",
+        source_url="https://example.org/clean",
+        license="CC0 1.0",
+        commercial_use_allowed=True,
+        attribution_required=False,
+    )
+    fields.update(overrides)
+    return DatasetEntry(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Provenance validation
+# ---------------------------------------------------------------------------
+
+
+def test_clean_entry_has_no_issues():
+    assert validate_entry(_clean_entry()) == []
+
+
+def test_missing_license_is_an_error():
+    issues = validate_entry(_clean_entry(license=""))
+    assert any(i.severity == SEVERITY_ERROR and i.field == "license" for i in issues)
+
+
+def test_missing_source_url_is_an_error():
+    issues = validate_entry(_clean_entry(source_url="  "))
+    assert any(i.severity == SEVERITY_ERROR and i.field == "source_url" for i in issues)
+
+
+def test_unknown_commercial_use_is_a_warning():
+    issues = validate_entry(_clean_entry(commercial_use_allowed=None))
+    assert any(i.severity == SEVERITY_WARNING and i.field == "commercial_use_allowed" for i in issues)
+    assert not has_errors(issues)
+
+
+def test_fan_archive_tag_is_an_error():
+    issues = validate_entry(_clean_entry(tags=("piano", "Fan-Archive")))
+    tag_issues = [i for i in issues if i.field == "tags"]
+    assert tag_issues and tag_issues[0].severity == SEVERITY_ERROR
+    assert "reference/evaluation" in tag_issues[0].message
+
+
+def test_validate_manifest_reports_only_problem_entries():
+    entries = [_clean_entry(), _clean_entry(name="bad-set", license="", source_url="")]
+    report = validate_manifest(entries)
+    assert set(report) == {"bad-set"}
+    assert has_errors(report["bad-set"])
+
+
+def test_assert_training_ready_raises_with_error_details():
+    with pytest.raises(ValueError, match="not training-ready"):
+        assert_training_ready(_clean_entry(license="", tags=("unclear-rights",)))
+    assert_training_ready(_clean_entry())  # clean entry passes
+
+
+# ---------------------------------------------------------------------------
+# License policy
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_license_strips_versions_and_case():
+    assert normalize_license("CC BY-NC-SA 4.0") == "cc-by-nc-sa"
+    assert normalize_license("Creative Commons BY 4.0") == "cc-by"
+    assert normalize_license("MIT License") == "mit"
+    assert normalize_license("Public Domain") == "public-domain"
+    assert normalize_license("CC0 1.0") == "cc0"
+
+
+def test_assess_license_known_and_unknown():
+    nc = assess_license("CC BY-NC-SA 4.0")
+    assert nc.known and nc.commercial_use is False and nc.attribution_required is True
+    mystery = assess_license("found on a forum")
+    assert not mystery.known
+    assert mystery.commercial_use is None
+
+
+def test_non_commercial_license_blocks_commercial_use():
+    entry = _clean_entry(license="CC BY-NC 4.0", commercial_use_allowed=None)
+    violations = check_entry_license(entry, intended_use="commercial")
+    assert violations and "does not permit commercial use" in violations[0]
+
+
+def test_unknown_license_is_unverified_for_commercial_use():
+    entry = _clean_entry(license="verify at source", commercial_use_allowed=None)
+    violations = check_entry_license(entry, intended_use="commercial")
+    assert violations and "unverified" in violations[0]
+
+
+def test_explicit_manifest_flag_overrides_license_table():
+    # A human verified commercial terms even though the license id is unknown.
+    entry = _clean_entry(license="custom vendor agreement", commercial_use_allowed=True)
+    assert check_entry_license(entry, intended_use="commercial") == []
+
+
+def test_missing_license_always_violates():
+    violations = check_entry_license(_clean_entry(license=""), intended_use="research")
+    assert violations and "no license recorded" in violations[0]
+
+
+def test_invalid_intended_use_rejected():
+    with pytest.raises(ValueError):
+        check_entry_license(_clean_entry(), intended_use="world-domination")
+
+
+# ---------------------------------------------------------------------------
+# Manifest loading
+# ---------------------------------------------------------------------------
+
+
+def test_example_manifest_loads_and_validates_as_designed():
+    entries = load_manifest(EXAMPLE_MANIFEST)
+    by_name = {entry.name: entry for entry in entries}
+    assert by_name["my-cc0-piano-set"].commercial_use_allowed is True
+    assert by_name["research-pop-arrangements"].tags == ("pop", "example")
+
+    report = validate_manifest(entries)
+    # The deliberately-bad fan-archive entry is flagged; the clean one is not.
+    assert "old-forum-game-midi-pack" in report
+    assert has_errors(report["old-forum-game-midi-pack"])
+    assert "my-cc0-piano-set" not in report
+
+
+def test_entry_from_dict_rejects_unknown_keys():
+    with pytest.raises(ValueError, match="Unknown dataset-manifest keys"):
+        entry_from_dict({"name": "x", "licence_notes": "typo"})
+
+
+def test_entry_from_dict_requires_name():
+    with pytest.raises(ValueError, match="'name'"):
+        entry_from_dict({"license": "CC0"})
+
+
+def test_missing_manifest_file_raises_without_downloading():
+    with pytest.raises(FileNotFoundError, match="never auto-downloaded"):
+        load_manifest("/nonexistent/manifest.json")
+
+
+def test_recommended_datasets_all_carry_provenance_fields():
+    for entry in RECOMMENDED_DATASETS:
+        assert entry.name
+        assert entry.source_url.startswith("http")
+        assert entry.license

--- a/tests/test_lightweight_imports.py
+++ b/tests/test_lightweight_imports.py
@@ -1,0 +1,72 @@
+"""Guard the lightweight install story: core + Stage 1.5 packages must not
+require (or even touch) the ML/audio/symbolic extras."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Everything that only the optional extras should ever pull in.
+FORBIDDEN_MODULES = (
+    "torch",
+    "torchaudio",
+    "transformers",
+    "sklearn",
+    "datasets",
+    "miditok",
+    "symusic",
+    "librosa",
+    "soundfile",
+    "demucs",
+    "spleeter",
+    "tensorflow",
+)
+
+CHECK_SCRIPT = f"""
+import sys
+sys.path.insert(0, {str(ROOT / "src")!r})
+import creative_audio_lab
+import creative_audio_lab.data
+import creative_audio_lab.evaluation
+import creative_audio_lab.export
+import creative_audio_lab.models
+import creative_audio_lab.preview
+import creative_audio_lab.tokenization
+loaded = [m for m in {FORBIDDEN_MODULES!r} if m in sys.modules]
+if loaded:
+    raise SystemExit("heavy modules loaded by core import: " + ", ".join(loaded))
+"""
+
+
+def test_core_packages_import_without_ml_audio_extras():
+    """Importing every creative_audio_lab package must not load any heavy extra."""
+    result = subprocess.run(
+        [sys.executable, "-c", CHECK_SCRIPT],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_app_module_imports_without_ml_audio_extras():
+    """`import app` (the Streamlit UI) needs streamlit but nothing heavier."""
+    pytest.importorskip("streamlit", reason="app extra not installed (core-only environment)")
+    script = (
+        f"import sys\n"
+        f"sys.path.insert(0, {str(ROOT)!r})\n"
+        f"import app\n"
+        f"loaded = [m for m in {FORBIDDEN_MODULES!r} if m in sys.modules]\n"
+        f"if loaded:\n"
+        f"    raise SystemExit('heavy modules loaded by app import: ' + ', '.join(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -37,7 +37,7 @@ def test_create_orchestral_midi():
 
 
 def test_program_change():
-    mido = pytest.importorskip("mido")
+    pytest.importorskip("mido")
     layers = {
         "piano": ([(0.0, 60, 1.0, 64)], 1),
         "strings": [(0.5, 67, 1.5, 64)],

--- a/tests/test_miditok_adapter.py
+++ b/tests/test_miditok_adapter.py
@@ -1,0 +1,39 @@
+import pytest
+
+from creative_audio_lab.tokenization.miditok_adapter import (
+    MidiTokNotAvailableError,
+    MidiTokRemiAdapter,
+    is_miditok_available,
+    require_miditok,
+)
+
+miditok_missing = not is_miditok_available()
+
+
+@pytest.mark.skipif(not miditok_missing, reason="miditok/symusic are installed in this environment")
+def test_adapter_raises_clear_error_when_miditok_missing():
+    with pytest.raises(MidiTokNotAvailableError) as excinfo:
+        MidiTokRemiAdapter()
+    message = str(excinfo.value)
+    assert "creative-audio-lab[symbolic]" in message
+    assert "SymbolicTokenizer" in message  # points at the dependency-free alternative
+
+
+@pytest.mark.skipif(not miditok_missing, reason="miditok/symusic are installed in this environment")
+def test_require_miditok_raises_when_missing():
+    with pytest.raises(MidiTokNotAvailableError):
+        require_miditok()
+
+
+def test_error_is_an_import_error_subclass():
+    # Callers guarding with `except ImportError` keep working.
+    assert issubclass(MidiTokNotAvailableError, ImportError)
+
+
+def test_availability_probe_does_not_import_heavy_modules():
+    import sys
+
+    is_miditok_available()
+    if miditok_missing:
+        assert "miditok" not in sys.modules
+        assert "symusic" not in sys.modules

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,116 @@
+import pytest
+
+from creative_audio_lab.models import DeterministicBackend
+from creative_audio_lab.music_theory import Note
+from creative_audio_lab.preview import build_piano_roll, summarize_arrangement, summarize_tracks
+from creative_audio_lab.preview.midi_summary import summarize_notes
+
+MELODY = [
+    Note(start=0.0, pitch=60, duration=1.0, velocity=96),
+    Note(start=1.0, pitch=64, duration=1.0, velocity=96),
+    Note(start=2.0, pitch=67, duration=2.0, velocity=100),
+    Note(start=4.0, pitch=72, duration=1.0, velocity=90),  # spills into bar 2
+]
+
+
+# ---------------------------------------------------------------------------
+# MIDI summary
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_notes_basic_stats():
+    summary = summarize_notes("melody", MELODY, program=73)
+    assert summary.note_count == 4
+    assert (summary.pitch_min, summary.pitch_max) == (60, 72)
+    assert summary.duration_beats == 5.0
+    assert summary.duration_bars == 2.0  # 5 beats rounds up to 2 bars of 4/4
+    assert summary.notes_per_bar == 2.0
+    assert summary.program == 73
+    assert summary.is_drum is False
+
+
+def test_summarize_notes_empty_track():
+    summary = summarize_notes("drums", [], is_drum=True)
+    assert summary.note_count == 0
+    assert summary.pitch_min is None and summary.pitch_max is None
+    assert summary.duration_bars == 0.0
+    assert summary.notes_per_bar == 0.0
+
+
+def test_summarize_tracks_piece_level_stats():
+    tracks = {"melody": MELODY, "drums": [Note(start=0.0, pitch=36, duration=0.25, velocity=110)]}
+    summary = summarize_tracks(tracks, programs={"melody": 73}, bpm=120)
+    assert summary.total_notes == 5
+    assert summary.duration_bars == 2.0
+    assert summary.has_drums is True
+    assert summary.bpm == 120
+    # Drum pitches are excluded from the pitched range.
+    assert summary.pitch_range == (60, 72)
+
+
+def test_summarize_arrangement_covers_all_parts():
+    arrangement = DeterministicBackend().generate(
+        "dark orchestral boss battle theme, 140 BPM, brass ostinato, strings, piano arps"
+    )
+    summary = summarize_arrangement(arrangement)
+    assert {track.name for track in summary.tracks} == {"chords", "melody", "bass", "drums"}
+    assert summary.total_notes > 0
+    assert summary.has_drums is True
+    assert summary.bpm == 140
+    assert summary.duration_bars >= arrangement.bars
+    assert summary.pitch_range is not None
+
+
+# ---------------------------------------------------------------------------
+# Piano roll
+# ---------------------------------------------------------------------------
+
+
+def test_piano_roll_grid_shape_and_content():
+    roll = build_piano_roll(MELODY, steps_per_beat=4)
+    assert roll.pitch_low == 60 and roll.pitch_high == 72
+    assert roll.num_pitches == 13
+    assert roll.num_steps == 20  # 5 beats * 4 steps
+    assert roll.duration_beats == 5.0
+    # First step: only middle C sounding, at its encoded velocity.
+    assert roll.active_pitches(0) == [60]
+    assert roll.grid[0][0] == 96
+    # Step 8 (beat 2): the held G.
+    assert roll.active_pitches(8) == [67]
+
+
+def test_piano_roll_short_note_occupies_at_least_one_step():
+    roll = build_piano_roll([Note(start=0.0, pitch=60, duration=0.01, velocity=80)], steps_per_beat=4)
+    assert roll.num_steps >= 1
+    assert roll.active_pitches(0) == [60]
+
+
+def test_piano_roll_overlapping_notes_keep_loudest_velocity():
+    notes = [
+        Note(start=0.0, pitch=60, duration=1.0, velocity=50),
+        Note(start=0.0, pitch=60, duration=0.5, velocity=110),
+    ]
+    roll = build_piano_roll(notes, steps_per_beat=4)
+    assert roll.grid[0][0] == 110
+    assert roll.grid[3][0] == 50  # after the loud note ends
+
+
+def test_piano_roll_empty_notes_yield_empty_grid():
+    roll = build_piano_roll([])
+    assert roll.num_steps == 0
+    assert roll.num_pitches == 0
+    assert roll.grid == ()
+
+
+def test_piano_roll_respects_explicit_pitch_bounds():
+    roll = build_piano_roll(MELODY, pitch_low=60, pitch_high=67)
+    assert roll.num_pitches == 8
+    # The C5 (72) note is out of range and skipped; its time span still exists.
+    assert roll.active_pitches(roll.num_steps - 1) == []
+
+
+def test_piano_roll_rejects_invalid_config():
+    with pytest.raises(ValueError):
+        build_piano_roll(MELODY, steps_per_beat=0)
+    with pytest.raises(ValueError):
+        build_piano_roll(MELODY, pitch_low=80, pitch_high=60)

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1,0 +1,142 @@
+from creative_audio_lab.generators.arrangement import build_arrangement
+from creative_audio_lab.music_theory import Note
+from creative_audio_lab.prompt_parser import parse_prompt
+from creative_audio_lab.tokenization import (
+    SymbolicTokenizer,
+    Token,
+    TokenType,
+    TokenizerConfig,
+    strings_to_tokens,
+    token_from_string,
+    tokens_to_strings,
+)
+
+import pytest
+
+SIMPLE_PHRASE = [
+    Note(start=0.0, pitch=60, duration=1.0, velocity=96),
+    Note(start=1.0, pitch=62, duration=0.5, velocity=92),
+    Note(start=1.5, pitch=64, duration=0.5, velocity=92),
+    Note(start=2.0, pitch=67, duration=2.0, velocity=100),
+    Note(start=4.0, pitch=65, duration=1.0, velocity=88),  # second bar
+]
+
+
+def test_encode_single_note_produces_expected_tokens():
+    tokens = SymbolicTokenizer().encode([Note(start=0.0, pitch=60, duration=1.0, velocity=96)])
+    assert [t.type for t in tokens] == [
+        TokenType.BAR,
+        TokenType.POSITION,
+        TokenType.NOTE_ON,
+        TokenType.VELOCITY,
+        TokenType.DURATION,
+    ]
+    assert tokens[0].value == 0  # bar index
+    assert tokens[1].value == 0  # position step within bar
+    assert tokens[2].value == 60  # pitch
+    assert tokens[3].value == 24  # velocity 96 // bin width 4
+    assert tokens[4].value == 4  # 1 beat at 4 steps/beat
+
+
+def test_encode_emits_metadata_header_tokens():
+    tokenizer = SymbolicTokenizer()
+    tokens = tokenizer.encode(SIMPLE_PHRASE, tempo=120, program=48, time_signature="4/4")
+    assert tokens[0] == Token(TokenType.TEMPO, 120)
+    assert tokens[1] == Token(TokenType.TIME_SIGNATURE, "4/4")
+    assert tokens[2] == Token(TokenType.PROGRAM, 48)
+
+
+def test_encode_emits_bar_token_on_bar_change():
+    tokens = SymbolicTokenizer().encode(SIMPLE_PHRASE)
+    bar_tokens = [t for t in tokens if t.type is TokenType.BAR]
+    assert [t.value for t in bar_tokens] == [0, 1]
+
+
+def test_decode_tokens_to_note():
+    tokens = [
+        Token(TokenType.BAR, 1),
+        Token(TokenType.POSITION, 8),
+        Token(TokenType.NOTE_ON, 72),
+        Token(TokenType.VELOCITY, 25),
+        Token(TokenType.DURATION, 2),
+    ]
+    decoded = SymbolicTokenizer().decode(tokens)
+    assert decoded.notes == (Note(start=6.0, pitch=72, duration=0.5, velocity=100),)
+
+
+def test_decode_uses_default_velocity_when_velocity_token_missing():
+    tokens = [
+        Token(TokenType.BAR, 0),
+        Token(TokenType.POSITION, 0),
+        Token(TokenType.NOTE_ON, 60),
+        Token(TokenType.DURATION, 4),
+    ]
+    decoded = SymbolicTokenizer().decode(tokens)
+    assert decoded.notes[0].velocity == 96
+
+
+def test_decode_drops_note_on_without_duration():
+    tokens = [
+        Token(TokenType.BAR, 0),
+        Token(TokenType.POSITION, 0),
+        Token(TokenType.NOTE_ON, 60),
+        Token(TokenType.NOTE_ON, 64),
+        Token(TokenType.VELOCITY, 24),
+        Token(TokenType.DURATION, 4),
+    ]
+    decoded = SymbolicTokenizer().decode(tokens)
+    assert [note.pitch for note in decoded.notes] == [64]
+
+
+def test_roundtrip_simple_phrase_is_exact():
+    tokenizer = SymbolicTokenizer()
+    tokens = tokenizer.encode(SIMPLE_PHRASE, tempo=100, program=0, time_signature="4/4")
+    decoded = tokenizer.decode(tokens)
+    assert list(decoded.notes) == SIMPLE_PHRASE
+    assert decoded.tempo == 100
+    assert decoded.program == 0
+    assert decoded.time_signature == "4/4"
+
+
+def test_roundtrip_generated_chords_part():
+    controls = parse_prompt("romantic piano loop in C minor, 90 BPM")
+    arrangement = build_arrangement(controls)
+    chords = arrangement.parts["chords"]
+    tokenizer = SymbolicTokenizer()
+    decoded = tokenizer.decode(tokenizer.encode(chords, tempo=arrangement.bpm))
+    assert sorted(decoded.notes, key=lambda n: (n.start, n.pitch)) == sorted(
+        chords, key=lambda n: (n.start, n.pitch)
+    )
+
+
+def test_roundtrip_via_token_strings():
+    tokenizer = SymbolicTokenizer()
+    strings = tokenizer.encode_to_strings(SIMPLE_PHRASE, time_signature="4/4")
+    assert all(isinstance(s, str) for s in strings)
+    decoded = tokenizer.decode_from_strings(strings)
+    assert list(decoded.notes) == SIMPLE_PHRASE
+
+
+def test_token_string_forms_parse_back():
+    tokens = [
+        Token(TokenType.NOTE_ON, 60),
+        Token(TokenType.TIME_SIGNATURE, "4/4"),
+        Token(TokenType.BAR, 3),
+    ]
+    strings = tokens_to_strings(tokens)
+    assert strings == ["NOTE_ON_60", "TIME_SIGNATURE_4/4", "BAR_3"]
+    assert strings_to_tokens(strings) == tokens
+
+
+def test_token_from_string_rejects_garbage():
+    with pytest.raises(ValueError):
+        token_from_string("NOT_A_TOKEN_TYPE_5")
+    with pytest.raises(ValueError):
+        token_from_string("nounderscore")
+
+
+def test_duration_is_capped_at_max_duration():
+    config = TokenizerConfig(max_duration_beats=2.0)
+    tokens = SymbolicTokenizer(config).encode([Note(start=0.0, pitch=60, duration=16.0, velocity=96)])
+    duration_token = next(t for t in tokens if t.type is TokenType.DURATION)
+    assert duration_token.value == 8  # 2 beats * 4 steps/beat


### PR DESCRIPTION
## Summary

Advances Creative Audio Lab from a deterministic Prompt-to-MIDI prototype toward a credible ML-ready symbolic music platform. The deterministic generator remains the default backend, the core install stays `mido` + `numpy`, and **no model is trained, bundled, or downloaded** — this pass builds the scaffolding a future text-conditioned symbolic model needs.

## What's new

### Symbolic tokenization (`creative_audio_lab.tokenization`)
- **`SymbolicTokenizer`** — dependency-free, REMI-style tokenizer converting `Note` events to/from flat token sequences (`BAR`, `POSITION`, `PROGRAM`, `NOTE_ON`, `DURATION`, `VELOCITY`, `TEMPO`, `TIME_SIGNATURE`). Grid-aligned notes (everything the deterministic generators emit) round-trip exactly.
- **`MidiTokRemiAdapter`** — optional wrapper around MidiTok REMI for tokenizing external MIDI files. Without `miditok`/`symusic` installed it raises `MidiTokNotAvailableError` with a clear install hint (`pip install "creative-audio-lab[symbolic]"`) and points at the dependency-free alternative.

### Dataset provenance (`creative_audio_lab.data`)
- `DatasetEntry` now records name, local path, source URL, license, `commercial_use_allowed`, `attribution_required`, notes, and tags.
- **`provenance.validate_entry`** errors on missing license/source URL and on fan-archive/unclear-rights tags; warns on unverified commercial terms. `assert_training_ready` blocks unfit datasets outright.
- **`license_policy`** classifies common licenses (CC family, MIT/BSD/Apache, research-only) and checks entries against research vs. commercial use.
- `RECOMMENDED_DATASETS` expanded with MidiCaps, MetaScore (public subset), Slakh2100, ComMU, EMOPIA, Aria-MIDI, and the music21 corpus — all with provenance fields.
- `examples/dataset_manifest.example.json` uses placeholder paths only; nothing is ever downloaded automatically.

### Backend interface (`creative_audio_lab.models`)
- **`GenerationBackend`** ABC: `generate(prompt, key=..., mode=..., bpm=..., ...) -> Arrangement`, plus availability metadata for UIs.
- **`DeterministicBackend`** wraps the existing parser + arrangement generators and stays the default.
- **`Text2MidiAdapter`** / **`MidiLlmAdapter`** are placeholder adapters: they import nothing heavy, report `is_available == False`, and raise `NotImplementedError` with concrete step-by-step integration guidance.

### Preview layer (`creative_audio_lab.preview`)
- Per-track and piece-level MIDI summaries (note counts, pitch range, duration in bars, density per track, drum presence).
- `PianoRoll` — a quantized pitch/time velocity grid data structure (data only, no rendered image, no audio).

### Streamlit app
- Generates through `DeterministicBackend` instead of calling the parser/generator directly.
- New **Backend** sidebar section: deterministic baseline selectable; Text2midi and MIDI-LLM shown as locked/scaffolded entries; an **ML readiness** expander explains what exists and what doesn't.
- Track-summary table powered by the preview layer.

### Packaging & docs
- New `symbolic` extra (`miditok`, `symusic`); `torch`/`transformers` remain in the `ml` extra. Core dependencies unchanged.
- README gains a "Stage 1.5: ML-ready architecture" section (including why there's still no trained model); `docs/ML_ROADMAP.md` gains Stage 1.5 between the deterministic baseline and dataset ingestion; `docs/DATASETS.md` adds the new dataset candidates with licensing warnings and an explicit fan-OST/game-MIDI "private reference/evaluation only" rule.

## Testing

- 57 new tests: tokenizer encode/decode/roundtrips, missing-MidiTok error path, provenance and license-policy validation, backend interface shape and deterministic-backend equivalence, placeholder-adapter guidance, MIDI summary, piano roll, and subprocess-based guards that core/app imports pull in no ML/audio/symbolic packages.
- Full suite: **139 passed, 1 skipped** (pre-existing skip); `ruff check src/ app.py tests/` clean.
- Verified `pip install -e .`, `pip install -e ".[dev]"`, and headless `streamlit run app.py` (HTTP 200, script executes with no heavy imports).
- CI workflow unchanged — still `pip install -e ".[dev]"` + `pytest`, no extras required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYRLtDFeC7aGJx4fMKw8eB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYRLtDFeC7aGJx4fMKw8eB)_