### PR TITLE
Add MIT license and update project metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 *.pyc
 *.egg-info/
 .pytest_cache/
+.ruff_cache/
+.coverage
+venv/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ghobi A
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Creative Audio Lab
 
+**What this is:** a symbolic-music engineering project — deterministic,
+rule-based MIDI generation with the architecture laid out for an ML
+pipeline to be added later. It is not a trained-model or applied-ML
+portfolio piece; today's generation logic is rules and music theory, not
+a learned model.
+
 **Prompt-to-MIDI Generator** — a prompt-conditioned symbolic music generator
 that creates DAW-ready MIDI arrangements instead of finished audio.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "creative-audio-lab"
 version = "0.1.0"
 description = "A prompt-conditioned symbolic music generator that creates DAW-ready MIDI arrangements instead of finished audio."
 readme = "README.md"
+license = {file = "LICENSE"}
 requires-python = ">=3.9"
 dependencies = [
     "mido",


### PR DESCRIPTION
## Summary
This PR adds licensing information to the project and updates configuration files to reflect the project's legal and development setup.

## Key Changes
- **Added MIT License**: New LICENSE file with MIT license text (copyright 2026 Ghobi A)
- **Updated README.md**: Added clarification section explaining that this is a rule-based symbolic music engineering project with deterministic MIDI generation, not an ML-based portfolio piece
- **Updated .gitignore**: Added entries for `.ruff_cache/`, `.coverage`, and `venv/` to exclude development artifacts and virtual environments
- **Updated pyproject.toml**: Added license file reference to project metadata

## Notable Details
The README update provides important context about the project's approach, emphasizing that the current generation logic is based on rules and music theory rather than trained machine learning models, while noting that the architecture is designed to accommodate an ML pipeline in the future.

https://claude.ai/code/session_01DcXwjripgaF1q1QBoQBsSQ